### PR TITLE
Fix GetApplicationDirectory() null termination error

### DIFF
--- a/src/core/support/Common.cpp
+++ b/src/core/support/Common.cpp
@@ -76,7 +76,7 @@ std::string musik::core::GetApplicationDirectory() {
         result = result.substr(0, last); /* remove filename component */
     #else
         std::string pathToProc = boost::str(boost::format("/proc/%d/exe") % (int) getpid());
-        char pathbuf[PATH_MAX + 1];
+        char pathbuf[PATH_MAX + 1] = { 0 };
         readlink(pathToProc.c_str(), pathbuf, PATH_MAX);
         result.assign(pathbuf);
         size_t last = result.find_last_of("/");


### PR DESCRIPTION
`readlink` is used to find the directory the executable resides in,
however `readlink` does not null terminate the returned string. If the
buffer does not have zero bytes at the end already, then you can have
errors. In my case, I was getting reports from `valgrind` about `strlen` (called when you do `result.assign(pathbuf)` probably) reading uninitialized memory, indicating it likely read past the end of of `pathbuf`.

Note that setting the `char` buffer to zero beforehand is sufficient because you already made it one character longer then was needed, so `readlink` will never write over the last `char`.