### PR TITLE
Truncate should use display width instead of # characters

### DIFF
--- a/src/musikcube/cursespp/Text.cpp
+++ b/src/musikcube/cursespp/Text.cpp
@@ -51,8 +51,10 @@ namespace cursespp {
                 auto it = str.begin();
                 auto end = str.end();
 
-                size_t c = 0;
-                while (c < len && it != str.end()) {
+                size_t cols = 0;
+                while (it != str.end()) {
+                    auto prev = it;
+
                     try {
                         utf8::next(it, end);
                     }
@@ -61,10 +63,13 @@ namespace cursespp {
                         ++it;
                     }
 
-                    ++c;
-                }
+                    size_t c = u8cols(std::string(prev, it));
+                    if (cols + c > len) {
+                        return std::string(str.begin(), prev);
+                    }
 
-                return std::string(str.begin(), it);
+                    cols += c;
+                }
             }
 
             return str;

--- a/src/musikcube/cursespp/Text.cpp
+++ b/src/musikcube/cursespp/Text.cpp
@@ -48,12 +48,13 @@ namespace cursespp {
             /* not a simple substr anymore, gotta deal with multi-byte
             characters... */
             if (u8cols(str) > len) {
+                auto prev = str.begin();
                 auto it = str.begin();
                 auto end = str.end();
 
                 size_t cols = 0;
-                while (it != str.end()) {
-                    auto prev = it;
+                while (cols <= len && it != str.end()) {
+                    prev = it;
 
                     try {
                         utf8::next(it, end);
@@ -63,13 +64,10 @@ namespace cursespp {
                         ++it;
                     }
 
-                    size_t c = u8cols(std::string(prev, it));
-                    if (cols + c > len) {
-                        return std::string(str.begin(), prev);
-                    }
-
-                    cols += c;
+                    cols += u8cols(std::string(prev, it));
                 }
+
+                return std::string(str.begin(), prev);
             }
 
             return str;
@@ -77,7 +75,14 @@ namespace cursespp {
 
         std::string Ellipsize(const std::string& str, size_t len) {
             if (u8cols(str) > len) {
-                return Truncate(str, len - 2) + "..";
+                std::string trunc = Truncate(str, len - 2);
+
+                size_t tlen = u8cols(trunc);
+                for (size_t i = tlen; i < len; i++) {
+                    trunc += ".";
+                }
+
+                return trunc;
             }
 
             return str;


### PR DESCRIPTION
Was having some display issues with wider display width characters:

![screen shot 2017-07-26 at 20 21 20](https://user-images.githubusercontent.com/3465699/28649383-82f5e9f0-7242-11e7-9f3e-bebae1f9a6e6.png)

Took a look around and it seems that Truncate doesn't take into account the display width of characters (aside from the initial u8cols check) - changed it to do so and it looks to have fixed the issue:

![screen shot 2017-07-26 at 20 30 11](https://user-images.githubusercontent.com/3465699/28649524-78806b98-7243-11e7-99b7-400ab50936a1.png)

I'm not particularly familiar with C++/unicode handling though so I'd appreciate any review on this.