### PR TITLE
Move quote in CMakeLists to avoid creating ;-separated list.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ ExternalProject_Add(taglib
     INSTALL_COMMAND make install
 )
 
-set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "-std=c++14 -Wno-unused-result -Wno-deprecated-declarations")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -Wno-unused-result -Wno-deprecated-declarations")
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O2")
 


### PR DESCRIPTION
On FreeBSD 10.3 with cmake 3.8.2 the cmake currently creates a semicolon separated list which leads to a "no input file" error on compilation. With the proposed fix it still builds and works fine on Ubuntu 16.04. with cmake 3.5.1.