### PR TITLE
Don't fallback to track artist when no album artist is present

### DIFF
--- a/src/core/library/track/IndexerTrack.cpp
+++ b/src/core/library/track/IndexerTrack.cpp
@@ -741,10 +741,6 @@ void IndexerTrack::SaveDirectory(db::Connection& db, const std::string& filename
 bool IndexerTrack::Save(db::Connection &dbConnection, std::string libraryDirectory) {
     std::unique_lock<std::mutex> lock(sharedWriteMutex);
 
-    if (this->GetString("album_artist") == "") {
-        this->SetValue("album_artist", this->GetString("artist").c_str());
-    }
-
     if (this->GetString("external_id") == "") {
         this->SetValue("external_id", createTrackExternalId(*this).c_str());
     }


### PR DESCRIPTION
So currently when no album artist is present, it will be set to the track artist. 

While this sound okay, the album collector is based on `{album-name}-{album-artist}`, so if a full album has no album artist set, there will be multiple versions of that album in the album list which is not really what we want to happen imo. we just want it to match on the name in that case.

So hereby I would like to remove the fallback.