### PR TITLE
Add default MacPorts link_directories and include_directories config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,9 +78,12 @@ include_directories (
 )
 
 # "/usr/local" doesn't seem to be included by default on macOS 10.12+
+# "/opt/local" is the default installation location for MacPorts
 if (CMAKE_SYSTEM_NAME MATCHES "Darwin")
   link_directories ("/usr/local/lib")
   include_directories("/usr/local/include")
+  link_directories ("/opt/local/lib")
+  include_directories("/opt/local/include")
 endif ()
 
 if (EXISTS "/etc/arch-release" OR EXISTS "/etc/manjaro-release" OR NO_NCURSESW)


### PR DESCRIPTION
MacPorts installs libs and includes to `/opt/local/{lib,include}`.

With these paths added to CMake config, the build instructions for musikcube in a MacPorts dev environment is the same as for Homebrew.

Feel free to merge if useful, ignore if not! :)

Thanks for making musikcube!