### PR TITLE
Include fstream

### DIFF
--- a/src/musikcubed/main.cpp
+++ b/src/musikcubed/main.cpp
@@ -1,10 +1,10 @@
 #include <iostream>
+#include <fstream>
 
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <signal.h>
-#include <iostream>
 
 #include <core/audio/PlaybackService.h>
 #include <core/audio/MasterTransport.h>


### PR DESCRIPTION
fstream is not included in "src/musikcubed/main.cpp" and causes the following compilation error:
```
[ 98%] Building CXX object src/musikcube/CMakeFiles/musikcube.dir/cursespp/Window.cpp.o
[ 99%] Linking CXX executable ../../bin/musikcube
[ 99%] Built target musikcube
Scanning dependencies of target musikcubed
[100%] Building CXX object src/musikcubed/CMakeFiles/musikcubed.dir/main.cpp.o
/tmp/musikcube/src/musikcubed/main.cpp: In function 'bool exitIfRunning()':
/tmp/musikcube/src/musikcubed/main.cpp:33:23: error: variable 'std::ifstream lock' has initializer but incomplete type
     std::ifstream lock(LOCKFILE);
                       ^
/tmp/musikcube/src/musikcubed/main.cpp: In function 'void startDaemon()':
/tmp/musikcube/src/musikcubed/main.cpp:73:23: error: variable 'std::ofstream lock' has initializer but incomplete type
     std::ofstream lock(LOCKFILE);
                       ^
make[2]: *** [src/musikcubed/CMakeFiles/musikcubed.dir/main.cpp.o] Error 1
src/musikcubed/CMakeFiles/musikcubed.dir/build.make:62: recipe for target 'src/musikcubed/CMakeFiles/musikcubed.dir/main.cpp.o' failed
CMakeFiles/Makefile2:282: recipe for target 'src/musikcubed/CMakeFiles/musikcubed.dir/all' failed
make[1]: *** [src/musikcubed/CMakeFiles/musikcubed.dir/all] Error 2
Makefile:127: recipe for target 'all' failed
make: *** [all] Error 2
```