### PR TITLE
create external art plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ ExternalProject_Add(taglib
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -Wno-unused-result -Wno-deprecated-declarations")
 
-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g")
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g -no-pie")
 # enable for additional memory checking with fsanitize
 # set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g3 -fsanitize=address,undefined")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O2")
@@ -98,6 +98,7 @@ add_subdirectory(src/plugins/nullout)
 add_subdirectory(src/plugins/server)
 add_subdirectory(src/plugins/httpdatastream)
 add_subdirectory(src/plugins/stockencoders)
+add_subdirectory(src/plugins/externalart)
 
 if (${FFMPEG_DECODER} MATCHES "true")
   add_subdirectory(src/plugins/ffmpegdecoder)
@@ -112,7 +113,7 @@ endif()
 
 add_dependencies(taglibreader taglib)
 
-add_dependencies(musikcube musikcore taglibreader nullout server httpdatastream stockencoders)
+add_dependencies(musikcube musikcore taglibreader nullout server httpdatastream stockencoders externalart)
 add_dependencies(musikcubed musikcube)
 
 if (CMAKE_SYSTEM_NAME MATCHES "Linux")

--- a/src/core/library/Indexer.cpp
+++ b/src/core/library/Indexer.cpp
@@ -375,7 +375,6 @@ void Indexer::ReadMetadataFromFile(
 
                     if ((*it)->Read(file.string().c_str(), store)) {
                         saveToDb = true;
-                        break;
                     }
                 }
             }

--- a/src/plugins/externalart/CMakeLists.txt
+++ b/src/plugins/externalart/CMakeLists.txt
@@ -1,0 +1,6 @@
+set (externalart_SOURCES
+  externalart_plugin.cpp
+  ExternalArtReader.cpp
+)
+
+add_library(externalart SHARED ${externalart_SOURCES})

--- a/src/plugins/externalart/ExternalArtReader.cpp
+++ b/src/plugins/externalart/ExternalArtReader.cpp
@@ -1,0 +1,104 @@
+//////////////////////////////////////////////////////////////////////////////
+//
+// Copyright (c) 2007-2017 musikcube team
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright notice,
+//      this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the author nor the names of other contributors may
+//      be used to endorse or promote products derived from this software
+//      without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////////
+
+#include "ExternalArtReader.h"
+
+#include <vector>
+#include <string>
+#include <boost/algorithm/string.hpp>
+#include <iostream>
+#include <fstream>
+
+using namespace musik::core::sdk;
+
+ExternalArtReader::ExternalArtReader() {
+}
+
+ExternalArtReader::~ExternalArtReader() {
+}
+
+void ExternalArtReader::Release() {
+    delete this;
+}
+
+bool ExternalArtReader::CanRead(const char *extension){
+    if (extension) {
+        std::string ext(extension);
+        boost::algorithm::to_lower(ext);
+
+        return
+            ext.compare("mp3") == 0 ||
+            ext.compare("ogg") == 0 ||
+            ext.compare("aac") == 0 ||
+            ext.compare("m4a") == 0 ||
+            ext.compare("flac") == 0 ||
+            ext.compare("ape") == 0 ||
+            ext.compare("mpc") == 0;
+    }
+
+    return false;
+}
+
+bool ExternalArtReader::Read(const char* uri, ITagStore *track) {
+    std::string path(uri);
+    std::string folder;
+
+    std::string::size_type lastSlash = path.find_last_of("/");
+    if (lastSlash != std::string::npos) {
+        folder = path.substr(0, lastSlash + 1).c_str();
+    }
+
+    bool success = true;
+
+    std::string album = "cover.jpg";
+    if (Exists(folder + album)) {
+        folder = folder + album;
+    }
+    
+    std::ifstream in(folder);
+    std::string contents((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    
+    track->SetThumbnail(contents.data(), contents.size());
+
+    return true;
+}
+
+bool ExternalArtReader::Exists(const std::string& path) {
+    if (FILE *file = fopen(path.c_str(), "r")) {
+        fclose(file);
+        return true;
+    } else {
+        return false;
+    }   
+}

--- a/src/plugins/externalart/ExternalArtReader.h
+++ b/src/plugins/externalart/ExternalArtReader.h
@@ -1,0 +1,51 @@
+//////////////////////////////////////////////////////////////////////////////
+//
+// Copyright (c) 2007-2017 musikcube team
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright notice,
+//      this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the author nor the names of other contributors may
+//      be used to endorse or promote products derived from this software
+//      without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////////
+
+#include <set>
+
+#include <string>
+#include <core/sdk/ITagReader.h>
+
+class ExternalArtReader : public musik::core::sdk::ITagReader {
+    public:
+        ExternalArtReader();
+        ~ExternalArtReader();
+
+        virtual bool Read(const char *uri, musik::core::sdk::ITagStore *target);
+        virtual bool CanRead(const char *extension);
+        virtual void Release();
+        
+    private:
+        bool Exists(const std::string& path);
+};

--- a/src/plugins/externalart/externalart_plugin.cpp
+++ b/src/plugins/externalart/externalart_plugin.cpp
@@ -1,0 +1,70 @@
+//////////////////////////////////////////////////////////////////////////////
+//
+// Copyright (c) 2007-2017 musikcube team
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright notice,
+//      this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the author nor the names of other contributors may
+//      be used to endorse or promote products derived from this software
+//      without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////////
+
+#include "ExternalArtReader.h"
+#include <core/sdk/constants.h>
+#include <core/sdk/IPlugin.h>
+
+#ifdef WIN32
+    #define DLLEXPORT __declspec(dllexport)
+#else
+    #define DLLEXPORT
+#endif
+
+#ifdef WIN32
+    BOOL APIENTRY DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserved) {
+        return TRUE;
+    }
+#endif
+
+class ExternalArtPlugin : public musik::core::sdk::IPlugin {
+    public:
+        virtual void Release() { delete this; }
+        virtual const char* Name() { return "External Art"; }
+        virtual const char* Version() { return "0.1.0"; }
+        virtual const char* Author() { return "dkanada"; }
+        virtual const char* Guid() { return "b153s8kj-ee98-39hd-ad32-4ff7f34828cd"; }
+        virtual bool Configurable() { return false; }
+        virtual void Configure() { }
+        virtual void Reload() { }
+        virtual int SdkVersion() { return musik::core::sdk::SdkVersion; }
+};
+
+extern "C" DLLEXPORT musik::core::sdk::ITagReader* GetTagReader() {
+    return new ExternalArtReader();
+}
+
+extern "C" DLLEXPORT musik::core::sdk::IPlugin* GetPlugin() {
+    return new ExternalArtPlugin();
+}


### PR DESCRIPTION
This is still a work in progress, just wanted to see what you think. Is there a better interface I can hook into for this functionality? I have been trying to think of a way to add image support for any category, since many services also include artist images. That would require a lot of work though, so I want to see if I can figure out the websocket client first.