### PR TITLE
Fix: let libc set length of resolved  in realpath

### DIFF
--- a/src/plugins/gmedecoder/Constants.h
+++ b/src/plugins/gmedecoder/Constants.h
@@ -221,6 +221,12 @@ static inline std::string canonicalizePath(const std::string& path) {
         delete[] dest;
     }
     return result8;
+#elif __gnu_linux__
+    char* realname = realpath(path.c_str(), NULL);
+    if (!realname) {
+	return "";
+    }
+    return std::string(realname);
 #else
     char realname[_POSIX_PATH_MAX];
     if (realpath(path.c_str(), realname) == 0) {


### PR DESCRIPTION
In linux libc's you can pass NULL as resolved argument in the realpath call, to let libc `alloc` the char buffer itself.

this solves the issue where `musikcube` is build with a smaller `_POSIX_PATH_MAX` than the current system it's running on.

currently if musikcube is ran on a system with a bigger `_POSIX_PATH_MAX` than it's been build with it will result in a buffer overflow, which looks like this:

```
[eater@momo musikcube]$ musikcube
*** buffer overflow detected ***: musikcube terminated
Aborted
```