### PR TITLE
Removed bash dependency from shell scripts

### DIFF
--- a/src/musikcube/musikcube.in
+++ b/src/musikcube/musikcube.in
@@ -1,5 +1,6 @@
-#!/usr/bin/env bash
-pushd @musikcube_INSTALL_DIR@/share/musikcube/ > /dev/null
-{
-  ./musikcube "$@" && popd
-} || popd > /dev/null
+#!/bin/sh
+
+set -eu
+
+cd "@musikcube_INSTALL_DIR@"/share/musikcube/
+exec ./musikcube "$@"

--- a/src/musikcubed/musikcubed.in
+++ b/src/musikcubed/musikcubed.in
@@ -1,5 +1,6 @@
-#!/usr/bin/env bash
-pushd @musikcube_INSTALL_DIR@/share/musikcube/ > /dev/null
-{
-  ./musikcubed "$@" && popd
-} || popd > /dev/null
+#!/bin/sh
+
+set -eu
+
+cd "@musikcube_INSTALL_DIR@"/share/musikcube/
+exec ./musikcubed "$@"


### PR DESCRIPTION
Current shell scripts can be easily replaced by others that do not require bash. I have also added "exec" to replace the current shell with the invoked process.