### PR TITLE
Fix missing include in sndio plugin

### DIFF
--- a/src/plugins/sndioout/SndioOut.cpp
+++ b/src/plugins/sndioout/SndioOut.cpp
@@ -39,6 +39,7 @@
 #include <math.h>
 #include <limits.h>
 #include <iostream>
+#include <functional>
 
 #define BUFFER_COUNT 16
 #define ERROR(str) std::cerr << "SndioOut Error: " << str << "\n";


### PR DESCRIPTION
Compiled this on Linux and this header was missing.