### PR TITLE
Second batch of experimental Android UI refactors

### DIFF
--- a/src/core/library/query/local/CategoryTrackListQuery.cpp
+++ b/src/core/library/query/local/CategoryTrackListQuery.cpp
@@ -138,7 +138,7 @@ void CategoryTrackListQuery::RegularQuery(musik::core::db::Connection &db) {
     std::string limitAndOffset = this->GetLimitAndOffset();
 
     if (this->filter.size()) {
-        trackFilter = " AND " + category::CATEGORY_TRACKLIST_FILTER;
+        trackFilter = category::CATEGORY_TRACKLIST_FILTER;
         args.push_back(category::StringArgument(this->filter));
         args.push_back(category::StringArgument(this->filter));
         args.push_back(category::StringArgument(this->filter));

--- a/src/musikdroid/app/src/main/java/io/casey/musikcube/remote/ui/albums/activity/AlbumBrowseActivity.kt
+++ b/src/musikdroid/app/src/main/java/io/casey/musikcube/remote/ui/albums/activity/AlbumBrowseActivity.kt
@@ -25,6 +25,7 @@ class AlbumBrowseActivity: FragmentActivityWithTransport() {
     override fun createContentFragment(): BaseFragment =
         (intent.extras ?: Bundle()).run {
             AlbumBrowseFragment.create(
+                applicationContext,
                 getString(Album.Extra.CATEGORY_NAME, ""),
                 getLong(Album.Extra.CATEGORY_ID, -1))
         }

--- a/src/musikdroid/app/src/main/java/io/casey/musikcube/remote/ui/albums/activity/AlbumBrowseActivity.kt
+++ b/src/musikdroid/app/src/main/java/io/casey/musikcube/remote/ui/albums/activity/AlbumBrowseActivity.kt
@@ -9,7 +9,7 @@ import io.casey.musikcube.remote.service.websocket.model.ICategoryValue
 import io.casey.musikcube.remote.ui.albums.constant.Album
 import io.casey.musikcube.remote.ui.albums.fragment.AlbumBrowseFragment
 import io.casey.musikcube.remote.ui.shared.activity.FragmentActivityWithTransport
-import io.casey.musikcube.remote.ui.shared.extension.EXTRA_TITLE_OVERRIDE
+import io.casey.musikcube.remote.ui.shared.constant.Shared
 import io.casey.musikcube.remote.ui.shared.fragment.BaseFragment
 import io.casey.musikcube.remote.util.Strings
 
@@ -42,7 +42,7 @@ class AlbumBrowseActivity: FragmentActivityWithTransport() {
         fun getStartIntent(context: Context, categoryName: String, categoryId: Long, categoryValue: String): Intent =
             getStartIntent(context, categoryName, categoryId).apply {
                 if (Strings.notEmpty(categoryValue)) {
-                    putExtra(EXTRA_TITLE_OVERRIDE, context.getString(R.string.albums_by_title, categoryValue))
+                    putExtra(Shared.Extra.TITLE_OVERRIDE, context.getString(R.string.albums_by_title, categoryValue))
                 }
             }
 

--- a/src/musikdroid/app/src/main/java/io/casey/musikcube/remote/ui/albums/activity/AlbumBrowseActivity.kt
+++ b/src/musikdroid/app/src/main/java/io/casey/musikcube/remote/ui/albums/activity/AlbumBrowseActivity.kt
@@ -9,11 +9,11 @@ import io.casey.musikcube.remote.service.websocket.model.ICategoryValue
 import io.casey.musikcube.remote.ui.albums.constant.Album
 import io.casey.musikcube.remote.ui.albums.fragment.AlbumBrowseFragment
 import io.casey.musikcube.remote.ui.shared.activity.FragmentActivityWithTransport
-import io.casey.musikcube.remote.ui.shared.extension.EXTRA_ACTIVITY_TITLE
+import io.casey.musikcube.remote.ui.shared.extension.EXTRA_TITLE_OVERRIDE
 import io.casey.musikcube.remote.ui.shared.fragment.BaseFragment
 import io.casey.musikcube.remote.util.Strings
 
-class AlbumBrowseActivity : FragmentActivityWithTransport() {
+class AlbumBrowseActivity: FragmentActivityWithTransport() {
     private val albums
         get() = content as AlbumBrowseFragment
 
@@ -42,7 +42,7 @@ class AlbumBrowseActivity : FragmentActivityWithTransport() {
         fun getStartIntent(context: Context, categoryName: String, categoryId: Long, categoryValue: String): Intent =
             getStartIntent(context, categoryName, categoryId).apply {
                 if (Strings.notEmpty(categoryValue)) {
-                    putExtra(EXTRA_ACTIVITY_TITLE, context.getString(R.string.albums_by_title, categoryValue))
+                    putExtra(EXTRA_TITLE_OVERRIDE, context.getString(R.string.albums_by_title, categoryValue))
                 }
             }
 

--- a/src/musikdroid/app/src/main/java/io/casey/musikcube/remote/ui/albums/fragment/AlbumBrowseFragment.kt
+++ b/src/musikdroid/app/src/main/java/io/casey/musikcube/remote/ui/albums/fragment/AlbumBrowseFragment.kt
@@ -1,5 +1,6 @@
 package io.casey.musikcube.remote.ui.albums.fragment
 
+import android.content.Context
 import android.os.Bundle
 import android.support.v4.view.ViewCompat
 import android.view.LayoutInflater
@@ -16,6 +17,7 @@ import io.casey.musikcube.remote.ui.albums.constant.Album
 import io.casey.musikcube.remote.ui.shared.activity.IFilterable
 import io.casey.musikcube.remote.ui.shared.activity.ITitleProvider
 import io.casey.musikcube.remote.ui.shared.activity.ITransportObserver
+import io.casey.musikcube.remote.ui.shared.constant.Shared
 import io.casey.musikcube.remote.ui.shared.extension.*
 import io.casey.musikcube.remote.ui.shared.fragment.BaseFragment
 import io.casey.musikcube.remote.ui.shared.mixin.DataProviderMixin
@@ -129,7 +131,8 @@ class AlbumBrowseFragment: BaseFragment(), IFilterable, ITitleProvider, ITranspo
                                 appCompatActivity,
                                 Metadata.Category.ALBUM,
                                 album.id,
-                                album.value)))
+                                album.value))
+                            .pushTo(pushContainerId))
                 false ->
                     startActivity(
                         TrackListActivity.getStartIntent(
@@ -147,11 +150,19 @@ class AlbumBrowseFragment: BaseFragment(), IFilterable, ITitleProvider, ITranspo
 
     companion object {
         const val TAG = "AlbumBrowseFragment"
-        fun create(categoryName: String = "", categoryId: Long = -1L): AlbumBrowseFragment =
+        fun create(context: Context,
+                   categoryName: String = "",
+                   categoryId: Long = -1L,
+                   categoryValue: String = ""): AlbumBrowseFragment =
             AlbumBrowseFragment().apply {
                 arguments = Bundle().apply {
                     putString(Album.Extra.CATEGORY_NAME, categoryName)
                     putLong(Album.Extra.CATEGORY_ID, categoryId)
+                    if (categoryValue.isNotBlank()) {
+                        putString(
+                            Shared.Extra.TITLE_OVERRIDE,
+                            context.getString(R.string.albums_by_title, categoryValue))
+                    }
                 }
             }
     }

--- a/src/musikdroid/app/src/main/java/io/casey/musikcube/remote/ui/albums/fragment/AlbumBrowseFragment.kt
+++ b/src/musikdroid/app/src/main/java/io/casey/musikcube/remote/ui/albums/fragment/AlbumBrowseFragment.kt
@@ -1,6 +1,7 @@
 package io.casey.musikcube.remote.ui.albums.fragment
 
 import android.os.Bundle
+import android.support.v4.view.ViewCompat
 import android.view.LayoutInflater
 import android.view.Menu
 import android.view.View
@@ -22,6 +23,7 @@ import io.casey.musikcube.remote.ui.shared.mixin.ItemContextMenuMixin
 import io.casey.musikcube.remote.ui.shared.mixin.PlaybackMixin
 import io.casey.musikcube.remote.ui.shared.view.EmptyListView
 import io.casey.musikcube.remote.ui.tracks.activity.TrackListActivity
+import io.casey.musikcube.remote.ui.tracks.fragment.TrackListFragment
 import io.casey.musikcube.remote.util.Debouncer
 import io.reactivex.rxkotlin.subscribeBy
 
@@ -55,6 +57,8 @@ class AlbumBrowseFragment: BaseFragment(), IFilterable, ITitleProvider, ITranspo
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View =
         inflater.inflate(this.getLayoutId(), container, false).apply {
+            ViewCompat.setElevation(this, extras.elevation)
+
             val recyclerView = findViewById<FastScrollRecyclerView>(R.id.recycler_view)
             setupDefaultRecyclerView(recyclerView, adapter)
 
@@ -114,9 +118,27 @@ class AlbumBrowseFragment: BaseFragment(), IFilterable, ITitleProvider, ITranspo
     }
 
     private val eventListener = object: AlbumBrowseAdapter.EventListener {
-        override fun onItemClicked(album: IAlbum) =
-            startActivity(TrackListActivity.getStartIntent(
-                appCompatActivity, Metadata.Category.ALBUM, album.id, album.value))
+        override fun onItemClicked(album: IAlbum) {
+            when (pushContainerId > 0) {
+                true ->
+                    pushWithToolbar(
+                        pushContainerId,
+                        "TracksForAlbum($album.id)",
+                        TrackListFragment.create(
+                            TrackListFragment.arguments(
+                                appCompatActivity,
+                                Metadata.Category.ALBUM,
+                                album.id,
+                                album.value)))
+                false ->
+                    startActivity(
+                        TrackListActivity.getStartIntent(
+                            appCompatActivity,
+                            Metadata.Category.ALBUM,
+                            album.id,
+                            album.value))
+            }
+        }
 
         override fun onActionClicked(view: View, album: IAlbum) {
             mixin(ItemContextMenuMixin::class.java)?.showForCategory(album, view)

--- a/src/musikdroid/app/src/main/java/io/casey/musikcube/remote/ui/albums/fragment/AlbumBrowseFragment.kt
+++ b/src/musikdroid/app/src/main/java/io/casey/musikcube/remote/ui/albums/fragment/AlbumBrowseFragment.kt
@@ -15,10 +15,7 @@ import io.casey.musikcube.remote.ui.albums.constant.Album
 import io.casey.musikcube.remote.ui.shared.activity.IFilterable
 import io.casey.musikcube.remote.ui.shared.activity.ITitleProvider
 import io.casey.musikcube.remote.ui.shared.activity.ITransportObserver
-import io.casey.musikcube.remote.ui.shared.extension.getLayoutId
-import io.casey.musikcube.remote.ui.shared.extension.initSearchMenu
-import io.casey.musikcube.remote.ui.shared.extension.initToolbarIfNecessary
-import io.casey.musikcube.remote.ui.shared.extension.setupDefaultRecyclerView
+import io.casey.musikcube.remote.ui.shared.extension.*
 import io.casey.musikcube.remote.ui.shared.fragment.BaseFragment
 import io.casey.musikcube.remote.ui.shared.mixin.DataProviderMixin
 import io.casey.musikcube.remote.ui.shared.mixin.ItemContextMenuMixin
@@ -38,7 +35,7 @@ class AlbumBrowseFragment: BaseFragment(), IFilterable, ITitleProvider, ITranspo
     private lateinit var emptyView: EmptyListView
 
     override val title: String
-        get() = app.getString(R.string.albums_title)
+        get() = getTitleOverride(app.getString(R.string.albums_title))
 
     override fun onCreate(savedInstanceState: Bundle?) {
         component.inject(this)
@@ -66,7 +63,7 @@ class AlbumBrowseFragment: BaseFragment(), IFilterable, ITitleProvider, ITranspo
             emptyView.emptyMessage = getString(R.string.empty_no_items_format, getString(R.string.browse_type_albums))
             emptyView.alternateView = recyclerView
 
-            initToolbarIfNecessary(this)
+            initToolbarIfNecessary(appCompatActivity, this)
         }
 
     override fun onResume() {

--- a/src/musikdroid/app/src/main/java/io/casey/musikcube/remote/ui/albums/fragment/AlbumBrowseFragment.kt
+++ b/src/musikdroid/app/src/main/java/io/casey/musikcube/remote/ui/albums/fragment/AlbumBrowseFragment.kt
@@ -15,7 +15,9 @@ import io.casey.musikcube.remote.ui.albums.constant.Album
 import io.casey.musikcube.remote.ui.shared.activity.IFilterable
 import io.casey.musikcube.remote.ui.shared.activity.ITitleProvider
 import io.casey.musikcube.remote.ui.shared.activity.ITransportObserver
+import io.casey.musikcube.remote.ui.shared.extension.getLayoutId
 import io.casey.musikcube.remote.ui.shared.extension.initSearchMenu
+import io.casey.musikcube.remote.ui.shared.extension.initToolbarIfNecessary
 import io.casey.musikcube.remote.ui.shared.extension.setupDefaultRecyclerView
 import io.casey.musikcube.remote.ui.shared.fragment.BaseFragment
 import io.casey.musikcube.remote.ui.shared.mixin.DataProviderMixin
@@ -55,7 +57,7 @@ class AlbumBrowseFragment: BaseFragment(), IFilterable, ITitleProvider, ITranspo
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View =
-        inflater.inflate(R.layout.recycler_view_fragment, container, false).apply {
+        inflater.inflate(this.getLayoutId(), container, false).apply {
             val recyclerView = findViewById<FastScrollRecyclerView>(R.id.recycler_view)
             setupDefaultRecyclerView(recyclerView, adapter)
 
@@ -63,6 +65,8 @@ class AlbumBrowseFragment: BaseFragment(), IFilterable, ITitleProvider, ITranspo
             emptyView.capability = EmptyListView.Capability.OnlineOnly
             emptyView.emptyMessage = getString(R.string.empty_no_items_format, getString(R.string.browse_type_albums))
             emptyView.alternateView = recyclerView
+
+            initToolbarIfNecessary(this)
         }
 
     override fun onResume() {

--- a/src/musikdroid/app/src/main/java/io/casey/musikcube/remote/ui/browse/activity/BrowseActivity.kt
+++ b/src/musikdroid/app/src/main/java/io/casey/musikcube/remote/ui/browse/activity/BrowseActivity.kt
@@ -33,6 +33,17 @@ class BrowseActivity: BaseActivity() {
         enableUpNavigation()
     }
 
+    override fun onBackPressed() {
+        when {
+            supportFragmentManager.backStackEntryCount > 0 -> {
+                supportFragmentManager.popBackStack()
+            }
+            else -> {
+                super.onBackPressed()
+            }
+        }
+    }
+
     private fun createFragments() {
         supportFragmentManager
             .beginTransaction()

--- a/src/musikdroid/app/src/main/java/io/casey/musikcube/remote/ui/browse/activity/BrowseActivity.kt
+++ b/src/musikdroid/app/src/main/java/io/casey/musikcube/remote/ui/browse/activity/BrowseActivity.kt
@@ -3,108 +3,57 @@ package io.casey.musikcube.remote.ui.browse.activity
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
-import android.support.design.widget.FloatingActionButton
-import android.support.design.widget.TabLayout
-import android.support.v4.view.ViewPager
-import android.view.Menu
-import android.view.View
 import io.casey.musikcube.remote.R
-import io.casey.musikcube.remote.ui.browse.adapter.BrowseFragmentAdapter
+import io.casey.musikcube.remote.ui.browse.constant.Browse
+import io.casey.musikcube.remote.ui.browse.fragment.BrowseFragment
 import io.casey.musikcube.remote.ui.shared.activity.BaseActivity
-import io.casey.musikcube.remote.ui.shared.activity.IFabConsumer
-import io.casey.musikcube.remote.ui.shared.activity.IFilterable
+import io.casey.musikcube.remote.ui.shared.activity.ITransportObserver
 import io.casey.musikcube.remote.ui.shared.extension.enableUpNavigation
 import io.casey.musikcube.remote.ui.shared.extension.findFragment
-import io.casey.musikcube.remote.ui.shared.extension.initSearchMenu
 import io.casey.musikcube.remote.ui.shared.fragment.TransportFragment
 
-class BrowseActivity: BaseActivity(), IFilterable {
-    private lateinit var transport: TransportFragment
-    private lateinit var pager: ViewPager
-    private lateinit var tabs: TabLayout
-    private lateinit var fab: FloatingActionButton
-    private lateinit var adapter: BrowseFragmentAdapter
-
+class BrowseActivity: BaseActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         setContentView(R.layout.browse_activity)
 
-        adapter = BrowseFragmentAdapter(this, supportFragmentManager)
-
-        pager = findViewById(R.id.view_pager)
-        pager.adapter = adapter
-        pager.currentItem = adapter.indexOf(extras.getString(EXTRA_INITIAL_CATEGORY_TYPE))
-
-        tabs = findViewById(R.id.tab_layout)
-        tabs.setupWithViewPager(pager)
-
-        fab = findViewById(R.id.fab)
-        fab.setOnClickListener {
-            (adapter.fragmentAt(pager.currentItem) as? IFabConsumer)?.onFabPress(fab)
+        if (savedInstanceState == null) {
+            createFragments()
         }
 
-        when (savedInstanceState == null) {
-            true -> createFragments()
-            else -> restoreFragments()
-        }
-
-        transport.modelChangedListener = {
-            adapter.onTransportChanged()
-        }
-
-        pager.addOnPageChangeListener(object: ViewPager.OnPageChangeListener {
-            override fun onPageScrollStateChanged(state: Int) {
-            }
-
-            override fun onPageScrolled(pos: Int, offset: Float, offsetPixels: Int) {
-            }
-
-            override fun onPageSelected(pos: Int) {
-                adapter.fragmentAt(pos)?.let {
-                    when (it is IFabConsumer) {
-                        true -> {
-                            when (it.fabVisible) {
-                                true -> fab.show()
-                                false -> fab.hide()
-                            }
-                        }
-                        false -> fab.hide()
-                    }
+        findFragment<TransportFragment>(TransportFragment.TAG).modelChangedListener = {
+            supportFragmentManager.fragments.forEach {
+                if (it is ITransportObserver) {
+                    it.onTransportChanged()
                 }
             }
-        })
+        }
 
         enableUpNavigation()
     }
 
-    override fun onCreateOptionsMenu(menu: Menu): Boolean {
-        return initSearchMenu(menu, this)
-    }
-
-    override fun setFilter(filter: String) {
-        adapter.filter = filter
-    }
-
     private fun createFragments() {
-        transport = TransportFragment.create()
         supportFragmentManager
             .beginTransaction()
-            .add(R.id.transport_container, transport, TransportFragment.TAG)
+            .add(
+                R.id.content_container,
+                BrowseFragment.create(extras),
+                BrowseFragment.TAG)
+            .add(
+                R.id.transport_container,
+                TransportFragment.create(),
+                TransportFragment.TAG)
             .commit()
-    }
 
-    private fun restoreFragments() {
-        transport = findFragment(TransportFragment.TAG)
+        supportFragmentManager.executePendingTransactions()
     }
 
     companion object {
-        private const val EXTRA_INITIAL_CATEGORY_TYPE = "extra_initial_category_type"
-
         fun getStartIntent(context: Context,
                            initialCategoryType: String = ""): Intent =
             Intent(context, BrowseActivity::class.java).apply {
-                putExtra(EXTRA_INITIAL_CATEGORY_TYPE, initialCategoryType)
+                putExtra(Browse.Extras.INITIAL_CATEGORY_TYPE, initialCategoryType)
             }
     }
 }

--- a/src/musikdroid/app/src/main/java/io/casey/musikcube/remote/ui/browse/adapter/BrowseFragmentAdapter.kt
+++ b/src/musikdroid/app/src/main/java/io/casey/musikcube/remote/ui/browse/adapter/BrowseFragmentAdapter.kt
@@ -13,8 +13,12 @@ import io.casey.musikcube.remote.ui.shared.activity.IFilterable
 import io.casey.musikcube.remote.ui.tracks.fragment.TrackListFragment
 import io.casey.musikcube.remote.service.playback.impl.remote.Metadata
 import io.casey.musikcube.remote.ui.shared.activity.ITransportObserver
+import io.casey.musikcube.remote.ui.shared.extension.pushTo
+import io.casey.musikcube.remote.ui.shared.fragment.BaseFragment
 
-class BrowseFragmentAdapter(private val context: Context, fm: FragmentManager): FragmentPagerAdapter(fm) {
+class BrowseFragmentAdapter(private val context: Context,
+                            fm: FragmentManager,
+                            private val containerId: Int = -1): FragmentPagerAdapter(fm) {
     private val fragments = mutableMapOf<Int, Fragment>()
 
     var filter = ""
@@ -41,15 +45,17 @@ class BrowseFragmentAdapter(private val context: Context, fm: FragmentManager): 
             else -> 0
         }
 
-    override fun getItem(index: Int): Fragment =
-        when (index) {
+    override fun getItem(index: Int): Fragment {
+        val fragment: BaseFragment = when (index) {
             0 -> CategoryBrowseFragment.create(
                 CategoryBrowseFragment.arguments(context, Metadata.Category.ALBUM_ARTIST))
-            1 -> AlbumBrowseFragment.create()
+            1 -> AlbumBrowseFragment.create(context)
             2 -> TrackListFragment.create()
             else -> CategoryBrowseFragment.create(
                 CategoryBrowseFragment.arguments(Metadata.Category.PLAYLISTS, NavigationType.Tracks))
         }
+        return fragment.pushTo(this.containerId)
+    }
 
     override fun getPageTitle(position: Int): CharSequence? =
         context.getString(when (position) {

--- a/src/musikdroid/app/src/main/java/io/casey/musikcube/remote/ui/browse/adapter/BrowseFragmentAdapter.kt
+++ b/src/musikdroid/app/src/main/java/io/casey/musikcube/remote/ui/browse/adapter/BrowseFragmentAdapter.kt
@@ -29,6 +29,8 @@ class BrowseFragmentAdapter(private val context: Context,
             }
         }
 
+    var onFragmentInstantiated: ((Int) -> Unit?)? = null
+
     fun onTransportChanged() =
         fragments.forEach {
             (it.value as? ITransportObserver)?.onTransportChanged()
@@ -73,6 +75,7 @@ class BrowseFragmentAdapter(private val context: Context,
         val result = super.instantiateItem(container, position)
         fragments[position] = result as Fragment
         (result as? IFilterable)?.setFilter(filter)
+        onFragmentInstantiated?.invoke(position)
         return result
     }
 }

--- a/src/musikdroid/app/src/main/java/io/casey/musikcube/remote/ui/browse/constant/Browse.kt
+++ b/src/musikdroid/app/src/main/java/io/casey/musikcube/remote/ui/browse/constant/Browse.kt
@@ -1,0 +1,7 @@
+package io.casey.musikcube.remote.ui.browse.constant
+
+object Browse {
+    object Extras {
+        const val INITIAL_CATEGORY_TYPE = "extra_initial_category_type"
+    }
+}

--- a/src/musikdroid/app/src/main/java/io/casey/musikcube/remote/ui/browse/fragment/BrowseFragment.kt
+++ b/src/musikdroid/app/src/main/java/io/casey/musikcube/remote/ui/browse/fragment/BrowseFragment.kt
@@ -1,0 +1,80 @@
+package io.casey.musikcube.remote.ui.browse.fragment
+
+import android.os.Bundle
+import android.support.design.widget.FloatingActionButton
+import android.support.design.widget.TabLayout
+import android.support.v4.view.ViewPager
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import io.casey.musikcube.remote.R
+import io.casey.musikcube.remote.ui.browse.adapter.BrowseFragmentAdapter
+import io.casey.musikcube.remote.ui.browse.constant.Browse
+import io.casey.musikcube.remote.ui.shared.activity.IFabConsumer
+import io.casey.musikcube.remote.ui.shared.activity.IFilterable
+import io.casey.musikcube.remote.ui.shared.activity.ITitleProvider
+import io.casey.musikcube.remote.ui.shared.activity.ITransportObserver
+import io.casey.musikcube.remote.ui.shared.extension.initToolbarIfNecessary
+import io.casey.musikcube.remote.ui.shared.fragment.BaseFragment
+
+class BrowseFragment: BaseFragment(), ITransportObserver, IFilterable, ITitleProvider {
+    private lateinit var adapter: BrowseFragmentAdapter
+
+    override val title: String
+        get() = getString(R.string.app_name)
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
+        inflater.inflate(R.layout.browse_fragment, container, false).apply {
+            adapter = BrowseFragmentAdapter(appCompatActivity, childFragmentManager)
+
+            val pager = findViewById<ViewPager>(R.id.view_pager)
+            pager.adapter = adapter
+            pager.currentItem = adapter.indexOf(extras.getString(Browse.Extras.INITIAL_CATEGORY_TYPE))
+
+            val tabs = findViewById<TabLayout>(R.id.tab_layout)
+            tabs.setupWithViewPager(pager)
+
+            val fab = findViewById<FloatingActionButton>(R.id.fab)
+            fab.setOnClickListener {
+                (adapter.fragmentAt(pager.currentItem) as? IFabConsumer)?.onFabPress(fab)
+            }
+
+            pager.addOnPageChangeListener(object: ViewPager.OnPageChangeListener {
+                override fun onPageScrollStateChanged(state: Int) {
+                }
+
+                override fun onPageScrolled(pos: Int, offset: Float, offsetPixels: Int) {
+                }
+
+                override fun onPageSelected(pos: Int) {
+                    adapter.fragmentAt(pos)?.let {
+                        when (it is IFabConsumer) {
+                            true -> {
+                                when (it.fabVisible) {
+                                    true -> fab.show()
+                                    false -> fab.hide()
+                                }
+                            }
+                            false -> fab.hide()
+                        }
+                    }
+                }
+            })
+
+            initToolbarIfNecessary(appCompatActivity, this)
+        }
+
+    override fun onTransportChanged() =
+        adapter.onTransportChanged()
+
+    override fun setFilter(filter: String) {
+        adapter.filter = filter
+    }
+
+    companion object {
+        const val TAG = "BrowseFragment"
+
+        fun create(extras: Bundle): BrowseFragment =
+            BrowseFragment().apply { arguments = extras }
+    }
+}

--- a/src/musikdroid/app/src/main/java/io/casey/musikcube/remote/ui/browse/fragment/BrowseFragment.kt
+++ b/src/musikdroid/app/src/main/java/io/casey/musikcube/remote/ui/browse/fragment/BrowseFragment.kt
@@ -26,7 +26,7 @@ class BrowseFragment: BaseFragment(), ITransportObserver, IFilterable, ITitlePro
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
         inflater.inflate(R.layout.browse_fragment, container, false).apply {
-            adapter = BrowseFragmentAdapter(appCompatActivity, childFragmentManager)
+            adapter = BrowseFragmentAdapter(appCompatActivity, childFragmentManager, R.id.content_container)
 
             val pager = findViewById<ViewPager>(R.id.view_pager)
             pager.adapter = adapter

--- a/src/musikdroid/app/src/main/java/io/casey/musikcube/remote/ui/browse/fragment/BrowseFragment.kt
+++ b/src/musikdroid/app/src/main/java/io/casey/musikcube/remote/ui/browse/fragment/BrowseFragment.kt
@@ -3,6 +3,7 @@ package io.casey.musikcube.remote.ui.browse.fragment
 import android.os.Bundle
 import android.support.design.widget.FloatingActionButton
 import android.support.design.widget.TabLayout
+import android.support.v4.view.ViewCompat
 import android.support.v4.view.ViewPager
 import android.view.LayoutInflater
 import android.view.View

--- a/src/musikdroid/app/src/main/java/io/casey/musikcube/remote/ui/category/fragment/CategoryBrowseFragment.kt
+++ b/src/musikdroid/app/src/main/java/io/casey/musikcube/remote/ui/category/fragment/CategoryBrowseFragment.kt
@@ -193,12 +193,14 @@ class CategoryBrowseFragment: BaseFragment(), IFilterable, ITitleProvider, ITran
     }
 
     private fun navigateToAlbums(entry: ICategoryValue) =
-        when (this.pushContainerId > 0) {
+        when (pushContainerId > 0) {
             true ->
                 this.pushWithToolbar(
-                    this.pushContainerId,
+                    pushContainerId,
                     "AlbumsBy($entry.value)",
-                    AlbumBrowseFragment.create(entry.type, entry.id))
+                    AlbumBrowseFragment
+                        .create(app, entry.type, entry.id, entry.value)
+                        .pushTo(pushContainerId))
             false ->
                 startActivity(AlbumBrowseActivity
                     .getStartIntent(appCompatActivity, category, entry))
@@ -212,7 +214,8 @@ class CategoryBrowseFragment: BaseFragment(), IFilterable, ITitleProvider, ITran
                     this.pushContainerId,
                     "TracksBy($entry.value)",
                     TrackListFragment.create(TrackListFragment
-                        .arguments(appCompatActivity, entry.type, entry.id)))
+                        .arguments(appCompatActivity, entry.type, entry.id))
+                    .pushTo(pushContainerId))
             false ->
                 startActivity(TrackListActivity.getStartIntent(
                     appCompatActivity, category, entry.id, entry.value))

--- a/src/musikdroid/app/src/main/java/io/casey/musikcube/remote/ui/category/fragment/CategoryBrowseFragment.kt
+++ b/src/musikdroid/app/src/main/java/io/casey/musikcube/remote/ui/category/fragment/CategoryBrowseFragment.kt
@@ -24,6 +24,7 @@ import io.casey.musikcube.remote.ui.shared.activity.IFabConsumer
 import io.casey.musikcube.remote.ui.shared.activity.IFilterable
 import io.casey.musikcube.remote.ui.shared.activity.ITitleProvider
 import io.casey.musikcube.remote.ui.shared.activity.ITransportObserver
+import io.casey.musikcube.remote.ui.shared.constant.Shared
 import io.casey.musikcube.remote.ui.shared.extension.*
 import io.casey.musikcube.remote.ui.shared.fragment.BaseFragment
 import io.casey.musikcube.remote.ui.shared.mixin.DataProviderMixin
@@ -255,7 +256,7 @@ class CategoryBrowseFragment: BaseFragment(), IFilterable, ITitleProvider, ITran
                     val format = Category.NAME_TO_RELATED_TITLE[category]
                     when (format) {
                         null -> throw IllegalArgumentException("unknown category $category")
-                        else -> putString(EXTRA_TITLE_OVERRIDE, context.getString(format, predicateValue))
+                        else -> putString(Shared.Extra.TITLE_OVERRIDE, context.getString(format, predicateValue))
                     }
                 }
             }

--- a/src/musikdroid/app/src/main/java/io/casey/musikcube/remote/ui/category/fragment/CategoryBrowseFragment.kt
+++ b/src/musikdroid/app/src/main/java/io/casey/musikcube/remote/ui/category/fragment/CategoryBrowseFragment.kt
@@ -47,9 +47,9 @@ class CategoryBrowseFragment: BaseFragment(), IFilterable, ITitleProvider, ITran
     override val title: String
         get() {
             Category.NAME_TO_TITLE[category]?.let {
-                return getString(it)
+                return getTitleOverride(getString(it))
             }
-            return Category.toDisplayString(app, category)
+            return getTitleOverride(Category.toDisplayString(app, category))
         }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -82,7 +82,7 @@ class CategoryBrowseFragment: BaseFragment(), IFilterable, ITitleProvider, ITran
             emptyView.alternateView = recyclerView
 
             setupDefaultRecyclerView(recyclerView, adapter)
-            initToolbarIfNecessary(this)
+            initToolbarIfNecessary(appCompatActivity, this)
         }
 
     override fun onFabPress(fab: FloatingActionButton) {
@@ -187,10 +187,10 @@ class CategoryBrowseFragment: BaseFragment(), IFilterable, ITitleProvider, ITran
     }
 
     private fun navigateToAlbums(entry: ICategoryValue) =
-            startActivity(AlbumBrowseActivity.getStartIntent(appCompatActivity, category, entry))
+        startActivity(AlbumBrowseActivity.getStartIntent(appCompatActivity, category, entry))
 
     private fun navigateToTracks(entry: ICategoryValue) =
-            startActivity(TrackListActivity.getStartIntent(appCompatActivity, category, entry.id, entry.value))
+        startActivity(TrackListActivity.getStartIntent(appCompatActivity, category, entry.id, entry.value))
 
     private fun navigateToSelect(id: Long, name: String) =
         appCompatActivity.run {
@@ -230,7 +230,7 @@ class CategoryBrowseFragment: BaseFragment(), IFilterable, ITitleProvider, ITran
                     val format = Category.NAME_TO_RELATED_TITLE[category]
                     when (format) {
                         null -> throw IllegalArgumentException("unknown category $category")
-                        else -> putString(EXTRA_ACTIVITY_TITLE, context.getString(format, predicateValue))
+                        else -> putString(EXTRA_TITLE_OVERRIDE, context.getString(format, predicateValue))
                     }
                 }
             }

--- a/src/musikdroid/app/src/main/java/io/casey/musikcube/remote/ui/category/fragment/CategoryBrowseFragment.kt
+++ b/src/musikdroid/app/src/main/java/io/casey/musikcube/remote/ui/category/fragment/CategoryBrowseFragment.kt
@@ -38,15 +38,24 @@ import io.reactivex.rxkotlin.subscribeBy
 
 class CategoryBrowseFragment: BaseFragment(), IFilterable, ITitleProvider, ITransportObserver, IFabConsumer {
     private lateinit var adapter: CategoryBrowseAdapter
-    private var navigationType: NavigationType = NavigationType.Albums
     private var lastFilter: String? = null
-    private var category: String = ""
-    private var predicateType: String = ""
-    private var predicateId: Long = -1
     private lateinit var rootView: View
     private lateinit var emptyView: EmptyListView
     private lateinit var data: DataProviderMixin
     private lateinit var playback: PlaybackMixin
+
+    private val navigationType: NavigationType
+        get() = NavigationType.get(extras.getInt(
+            Category.Extra.NAVIGATION_TYPE, NavigationType.Albums.ordinal))
+
+    private val category
+        get() = extras.getString(Category.Extra.CATEGORY, "")
+
+    private val predicateType: String
+        get() = extras.getString(Category.Extra.PREDICATE_TYPE, "")
+
+    private val predicateId: Long
+        get() = extras.getLong(Category.Extra.PREDICATE_ID, -1L)
 
     override val title: String
         get() {
@@ -63,13 +72,6 @@ class CategoryBrowseFragment: BaseFragment(), IFilterable, ITitleProvider, ITran
         data = mixin(DataProviderMixin())
         playback = mixin(PlaybackMixin())
         mixin(ItemContextMenuMixin(appCompatActivity, contextMenuListener, this))
-
-        extras.run {
-            category = getString(Category.Extra.CATEGORY, category)
-            predicateType = getString(Category.Extra.PREDICATE_TYPE, predicateType)
-            predicateId = getLong(Category.Extra.PREDICATE_ID, predicateId)
-            navigationType = NavigationType.get(getInt(Category.Extra.NAVIGATION_TYPE, navigationType.ordinal))
-        }
 
         adapter = CategoryBrowseAdapter(adapterListener, playback, navigationType, category, prefs)
     }

--- a/src/musikdroid/app/src/main/java/io/casey/musikcube/remote/ui/category/fragment/CategoryBrowseFragment.kt
+++ b/src/musikdroid/app/src/main/java/io/casey/musikcube/remote/ui/category/fragment/CategoryBrowseFragment.kt
@@ -22,9 +22,7 @@ import io.casey.musikcube.remote.ui.shared.activity.IFabConsumer
 import io.casey.musikcube.remote.ui.shared.activity.IFilterable
 import io.casey.musikcube.remote.ui.shared.activity.ITitleProvider
 import io.casey.musikcube.remote.ui.shared.activity.ITransportObserver
-import io.casey.musikcube.remote.ui.shared.extension.EXTRA_ACTIVITY_TITLE
-import io.casey.musikcube.remote.ui.shared.extension.initSearchMenu
-import io.casey.musikcube.remote.ui.shared.extension.setupDefaultRecyclerView
+import io.casey.musikcube.remote.ui.shared.extension.*
 import io.casey.musikcube.remote.ui.shared.fragment.BaseFragment
 import io.casey.musikcube.remote.ui.shared.mixin.DataProviderMixin
 import io.casey.musikcube.remote.ui.shared.mixin.ItemContextMenuMixin
@@ -73,7 +71,7 @@ class CategoryBrowseFragment: BaseFragment(), IFilterable, ITitleProvider, ITran
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
-        inflater.inflate(R.layout.recycler_view_fragment, container, false).apply {
+        inflater.inflate(this.getLayoutId(), container, false).apply {
             this@CategoryBrowseFragment.rootView = this
 
             val recyclerView = findViewById<FastScrollRecyclerView>(R.id.recycler_view)
@@ -84,6 +82,7 @@ class CategoryBrowseFragment: BaseFragment(), IFilterable, ITitleProvider, ITran
             emptyView.alternateView = recyclerView
 
             setupDefaultRecyclerView(recyclerView, adapter)
+            initToolbarIfNecessary(this)
         }
 
     override fun onFabPress(fab: FloatingActionButton) {

--- a/src/musikdroid/app/src/main/java/io/casey/musikcube/remote/ui/shared/activity/FragmentActivityWithTransport.kt
+++ b/src/musikdroid/app/src/main/java/io/casey/musikcube/remote/ui/shared/activity/FragmentActivityWithTransport.kt
@@ -3,6 +3,7 @@ package io.casey.musikcube.remote.ui.shared.activity
 import android.os.Bundle
 import android.support.design.widget.FloatingActionButton
 import android.view.Menu
+import android.view.MenuItem
 import io.casey.musikcube.remote.R
 import io.casey.musikcube.remote.ui.shared.extension.enableUpNavigation
 import io.casey.musikcube.remote.ui.shared.extension.findFragment
@@ -49,15 +50,32 @@ abstract class FragmentActivityWithTransport: BaseActivity(), IFilterable {
 
     override fun onResume() {
         super.onResume()
-        (content as? ITitleProvider)?.run {
-            setTitleFromIntent(this.title)
+        if (!content.hasToolbar) {
+            (content as? ITitleProvider)?.run {
+                setTitleFromIntent(this.title)
+            }
         }
     }
 
-    override fun onCreateOptionsMenu(menu: Menu): Boolean =
-        (content as? IMenuProvider)?.run {
-            return this.createOptionsMenu(menu)
-        } ?: false
+    override fun onCreateOptionsMenu(menu: Menu): Boolean {
+        if (!content.hasToolbar) {
+            (content as? IMenuProvider)?.run {
+                return this.createOptionsMenu(menu)
+            }
+        }
+        return false
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        if (!content.hasToolbar) {
+            (content as? IMenuProvider)?.run {
+                if (this.optionsItemSelected(item)) {
+                    return true
+                }
+            }
+        }
+        return super.onOptionsItemSelected(item)
+    }
 
     override fun setFilter(filter: String) =
         (content as? IFilterable)?.run {

--- a/src/musikdroid/app/src/main/java/io/casey/musikcube/remote/ui/shared/activity/FragmentActivityWithTransport.kt
+++ b/src/musikdroid/app/src/main/java/io/casey/musikcube/remote/ui/shared/activity/FragmentActivityWithTransport.kt
@@ -5,9 +5,7 @@ import android.support.design.widget.FloatingActionButton
 import android.view.Menu
 import android.view.MenuItem
 import io.casey.musikcube.remote.R
-import io.casey.musikcube.remote.ui.shared.extension.enableUpNavigation
-import io.casey.musikcube.remote.ui.shared.extension.findFragment
-import io.casey.musikcube.remote.ui.shared.extension.setTitleFromIntent
+import io.casey.musikcube.remote.ui.shared.extension.*
 import io.casey.musikcube.remote.ui.shared.fragment.BaseFragment
 import io.casey.musikcube.remote.ui.shared.fragment.TransportFragment
 
@@ -91,6 +89,8 @@ abstract class FragmentActivityWithTransport: BaseActivity(), IFilterable {
 
     private fun createFragments() {
         content = createContentFragment()
+            .withToolbar()
+            .withTitleOverride(this)
         transport = TransportFragment.create()
         supportFragmentManager
             .beginTransaction()

--- a/src/musikdroid/app/src/main/java/io/casey/musikcube/remote/ui/shared/activity/IMenuProvider.kt
+++ b/src/musikdroid/app/src/main/java/io/casey/musikcube/remote/ui/shared/activity/IMenuProvider.kt
@@ -1,7 +1,9 @@
 package io.casey.musikcube.remote.ui.shared.activity
 
 import android.view.Menu
+import android.view.MenuItem
 
 interface IMenuProvider {
     fun createOptionsMenu(menu: Menu): Boolean
+    fun optionsItemSelected(menuItem: MenuItem): Boolean
 }

--- a/src/musikdroid/app/src/main/java/io/casey/musikcube/remote/ui/shared/constant/Shared.kt
+++ b/src/musikdroid/app/src/main/java/io/casey/musikcube/remote/ui/shared/constant/Shared.kt
@@ -1,0 +1,10 @@
+package io.casey.musikcube.remote.ui.shared.constant
+
+object Shared {
+    object Extra {
+        const val TITLE_OVERRIDE = "extra_title_override"
+        const val WITH_TOOLBAR = "extra_with_toolbar"
+        const val PUSH_CONTAINER_ID = "extra_push_container_id"
+        const val ELEVATION = "extra_elevation"
+    }
+}

--- a/src/musikdroid/app/src/main/java/io/casey/musikcube/remote/ui/shared/extension/Extensions.kt
+++ b/src/musikdroid/app/src/main/java/io/casey/musikcube/remote/ui/shared/extension/Extensions.kt
@@ -189,7 +189,14 @@ val BaseFragment.pushContainerId: Int
     get() = this.extras.getInt(Shared.Extra.PUSH_CONTAINER_ID, -1)
 
 inline fun <reified T: BaseFragment> T.pushTo(containerId: Int): T {
-    this.extras.putInt(Shared.Extra.PUSH_CONTAINER_ID, containerId)
+    if (containerId > 0) {
+        this.extras.putInt(Shared.Extra.PUSH_CONTAINER_ID, containerId)
+    }
+    return this
+}
+
+inline fun <reified T: BaseFragment> T.pushTo(other: BaseFragment): T {
+    this.pushTo(other.pushContainerId)
     return this
 }
 

--- a/src/musikdroid/app/src/main/java/io/casey/musikcube/remote/ui/shared/fragment/BaseFragment.kt
+++ b/src/musikdroid/app/src/main/java/io/casey/musikcube/remote/ui/shared/fragment/BaseFragment.kt
@@ -8,8 +8,8 @@ import android.os.Handler
 import android.support.v4.app.Fragment
 import android.support.v7.app.AppCompatActivity
 import android.support.v7.widget.Toolbar
+import android.view.animation.Animation
 import io.casey.musikcube.remote.Application
-import io.casey.musikcube.remote.R
 import io.casey.musikcube.remote.framework.IMixin
 import io.casey.musikcube.remote.framework.MixinSet
 import io.casey.musikcube.remote.framework.ViewModel
@@ -20,6 +20,11 @@ import io.casey.musikcube.remote.ui.shared.activity.ITitleProvider
 import io.casey.musikcube.remote.ui.shared.extension.setTitleFromIntent
 import io.casey.musikcube.remote.ui.shared.mixin.ViewModelMixin
 import io.reactivex.disposables.CompositeDisposable
+import android.view.animation.AlphaAnimation
+import android.view.animation.AnimationUtils
+import io.casey.musikcube.remote.R
+import java.lang.Exception
+
 
 open class BaseFragment: Fragment(), ViewModel.Provider {
     private val mixins = MixinSet()
@@ -88,6 +93,26 @@ open class BaseFragment: Fragment(), ViewModel.Provider {
         mixins.onDestroy()
     }
 
+    /* https://stackoverflow.com/a/23276145 */
+    override fun onCreateAnimation(transit: Int, enter: Boolean, nextAnim: Int): Animation? {
+        val parent = parentFragment
+
+        /* only apply for childFragmentManager transitions */
+        return when (!enter && parent != null && parent.isRemoving) {
+            true -> {
+                /* this is a workaround for the bug where child fragments disappear when
+                the parent is removed (as all children are first removed from the parent)
+                See https://code.google.com/p/android/issues/detail?id=55228 */
+                val doNothingAnim = AlphaAnimation(1f, 1f)
+                doNothingAnim.duration = getNextAnimationDuration(parent, DEFAULT_CHILD_ANIMATION_DURATION)
+                doNothingAnim
+            }
+            false -> {
+                super.onCreateAnimation(transit, enter, nextAnim)
+            }
+        }
+    }
+
     override fun <T: ViewModel<*>> createViewModel(): T? = null
     protected fun <T: ViewModel<*>> getViewModel(): T? = mixin(ViewModelMixin::class.java)?.get<T>() as T
     protected fun <T: IMixin> mixin(mixin: T): T = mixins.add(mixin)
@@ -107,4 +132,25 @@ open class BaseFragment: Fragment(), ViewModel.Provider {
 
     val app: Application
         get() = Application.instance
+
+    companion object {
+        private const val DEFAULT_CHILD_ANIMATION_DURATION = 250L
+
+        private fun getNextAnimationDuration(fragment: Fragment, defValue: Long): Long =
+            try {
+                /* attempt to get the resource ID of the next animation that
+                will be applied to the given fragment. */
+                val nextAnimField = Fragment::class.java.getDeclaredField("mNextAnim")
+                nextAnimField.isAccessible = true
+                val nextAnimResource = nextAnimField.getInt(fragment)
+                val nextAnim = AnimationUtils.loadAnimation(fragment.activity, nextAnimResource)
+                when (nextAnim == null) {
+                    true -> defValue
+                    false -> nextAnim.duration
+                }
+            }
+            catch (ex: Exception) {
+                defValue
+            }
+    }
 }

--- a/src/musikdroid/app/src/main/java/io/casey/musikcube/remote/ui/shared/fragment/BaseFragment.kt
+++ b/src/musikdroid/app/src/main/java/io/casey/musikcube/remote/ui/shared/fragment/BaseFragment.kt
@@ -125,7 +125,12 @@ open class BaseFragment: Fragment(), ViewModel.Provider {
         get() = this.view?.findViewById(R.id.toolbar)
 
     val extras: Bundle
-        get() = arguments ?: Bundle()
+        get() {
+            if (arguments == null) {
+                arguments = Bundle()
+            }
+            return arguments!!
+        }
 
     val appCompatActivity: AppCompatActivity
         get() = activity as AppCompatActivity

--- a/src/musikdroid/app/src/main/java/io/casey/musikcube/remote/ui/shared/fragment/BaseFragment.kt
+++ b/src/musikdroid/app/src/main/java/io/casey/musikcube/remote/ui/shared/fragment/BaseFragment.kt
@@ -7,13 +7,17 @@ import android.os.Bundle
 import android.os.Handler
 import android.support.v4.app.Fragment
 import android.support.v7.app.AppCompatActivity
+import android.support.v7.widget.Toolbar
 import io.casey.musikcube.remote.Application
+import io.casey.musikcube.remote.R
 import io.casey.musikcube.remote.framework.IMixin
 import io.casey.musikcube.remote.framework.MixinSet
 import io.casey.musikcube.remote.framework.ViewModel
 import io.casey.musikcube.remote.injection.DaggerViewComponent
 import io.casey.musikcube.remote.injection.ViewComponent
 import io.casey.musikcube.remote.ui.settings.constants.Prefs
+import io.casey.musikcube.remote.ui.shared.activity.ITitleProvider
+import io.casey.musikcube.remote.ui.shared.extension.setTitleFromIntent
 import io.casey.musikcube.remote.ui.shared.mixin.ViewModelMixin
 import io.reactivex.disposables.CompositeDisposable
 
@@ -51,6 +55,9 @@ open class BaseFragment: Fragment(), ViewModel.Provider {
         super.onResume()
         paused = false
         mixins.onResume()
+        if (this is ITitleProvider) {
+            toolbar?.setTitleFromIntent(title)
+        }
     }
 
     override fun onPause() {
@@ -86,7 +93,13 @@ open class BaseFragment: Fragment(), ViewModel.Provider {
     protected fun <T: IMixin> mixin(mixin: T): T = mixins.add(mixin)
     protected fun <T: IMixin> mixin(cls: Class<out T>): T? = mixins.get(cls)
 
-    protected val extras: Bundle
+    val hasToolbar: Boolean
+        get() = this.toolbar != null
+
+    val toolbar: Toolbar?
+        get() = this.view?.findViewById(R.id.toolbar)
+
+    val extras: Bundle
         get() = arguments ?: Bundle()
 
     val appCompatActivity: AppCompatActivity

--- a/src/musikdroid/app/src/main/java/io/casey/musikcube/remote/ui/shared/fragment/TransportFragment.kt
+++ b/src/musikdroid/app/src/main/java/io/casey/musikcube/remote/ui/shared/fragment/TransportFragment.kt
@@ -28,7 +28,7 @@ class TransportFragment: BaseFragment() {
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View?
     {
-        this.rootView = inflater.inflate(R.layout.fragment_transport, container, false)
+        this.rootView = inflater.inflate(R.layout.transport_fragment, container, false)
         bindEventHandlers()
         rebindUi()
         return this.rootView

--- a/src/musikdroid/app/src/main/java/io/casey/musikcube/remote/ui/tracks/activity/TrackListActivity.kt
+++ b/src/musikdroid/app/src/main/java/io/casey/musikcube/remote/ui/tracks/activity/TrackListActivity.kt
@@ -7,12 +7,11 @@ import android.view.MenuItem
 import io.casey.musikcube.remote.R
 import io.casey.musikcube.remote.service.playback.impl.remote.Metadata
 import io.casey.musikcube.remote.ui.shared.activity.FragmentActivityWithTransport
-import io.casey.musikcube.remote.ui.shared.activity.IFilterable
 import io.casey.musikcube.remote.ui.shared.fragment.BaseFragment
 import io.casey.musikcube.remote.ui.tracks.constant.Track
 import io.casey.musikcube.remote.ui.tracks.fragment.TrackListFragment
 
-class TrackListActivity : FragmentActivityWithTransport(), IFilterable {
+class TrackListActivity: FragmentActivityWithTransport() {
     private val tracks
         get() = content as TrackListFragment
 

--- a/src/musikdroid/app/src/main/java/io/casey/musikcube/remote/ui/tracks/fragment/TrackListFragment.kt
+++ b/src/musikdroid/app/src/main/java/io/casey/musikcube/remote/ui/tracks/fragment/TrackListFragment.kt
@@ -17,6 +17,7 @@ import io.casey.musikcube.remote.ui.shared.activity.IFilterable
 import io.casey.musikcube.remote.ui.shared.activity.IMenuProvider
 import io.casey.musikcube.remote.ui.shared.activity.ITitleProvider
 import io.casey.musikcube.remote.ui.shared.activity.ITransportObserver
+import io.casey.musikcube.remote.ui.shared.constant.Shared
 import io.casey.musikcube.remote.ui.shared.extension.*
 import io.casey.musikcube.remote.ui.shared.fragment.BaseFragment
 import io.casey.musikcube.remote.ui.shared.mixin.DataProviderMixin
@@ -285,7 +286,7 @@ class TrackListFragment: BaseFragment(), IFilterable, ITitleProvider, ITransport
             putString(Track.Extra.CATEGORY_VALUE, categoryValue)
             if (Strings.notEmpty(categoryValue)) {
                 putString(
-                    EXTRA_TITLE_OVERRIDE,
+                    Shared.Extra.TITLE_OVERRIDE,
                     context.getString(R.string.songs_from_category, categoryValue))
             }
         }

--- a/src/musikdroid/app/src/main/java/io/casey/musikcube/remote/ui/tracks/fragment/TrackListFragment.kt
+++ b/src/musikdroid/app/src/main/java/io/casey/musikcube/remote/ui/tracks/fragment/TrackListFragment.kt
@@ -3,6 +3,7 @@ package io.casey.musikcube.remote.ui.tracks.fragment
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.support.v4.view.ViewCompat
 import android.support.v7.app.AppCompatActivity
 import android.view.*
 import com.simplecityapps.recyclerview_fastscroll.views.FastScrollRecyclerView
@@ -99,6 +100,8 @@ class TrackListFragment: BaseFragment(), IFilterable, ITitleProvider, ITransport
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View =
         inflater.inflate(this.getLayoutId(), container, false).apply {
+            ViewCompat.setElevation(this, extras.elevation)
+
             val recyclerView = findViewById<FastScrollRecyclerView>(R.id.recycler_view)
 
             tracks = DefaultSlidingWindow(recyclerView, data.provider, queryFactory)

--- a/src/musikdroid/app/src/main/res/drawable-v21/ic_back.xml
+++ b/src/musikdroid/app/src/main/res/drawable-v21/ic_back.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="?attr/colorControlNormal" android:pathData="M20,11H7.83l5.59,-5.59L12,4l-8,8 8,8 1.41,-1.41L7.83,13H20v-2z"/>
+</vector>

--- a/src/musikdroid/app/src/main/res/layout/browse_activity.xml
+++ b/src/musikdroid/app/src/main/res/layout/browse_activity.xml
@@ -1,58 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <android.support.design.widget.CoordinatorLayout
+    <FrameLayout
+        android:id="@+id/content_container"
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:layout_weight="1.0">
-
-        <android.support.design.widget.AppBarLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:theme="@style/ThemeOverlay.AppCompat.Dark">
-
-            <android.support.v7.widget.Toolbar
-                android:id="@+id/toolbar"
-                android:layout_width="match_parent"
-                android:layout_height="?attr/actionBarSize"
-                app:layout_scrollFlags="scroll|enterAlways|snap" />
-
-            <android.support.design.widget.TabLayout
-                android:id="@+id/tab_layout"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:background="@color/color_primary" />
-
-        </android.support.design.widget.AppBarLayout>
-
-        <android.support.v4.view.ViewPager
-            android:id="@+id/view_pager"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            app:layout_behavior="@string/appbar_scrolling_view_behavior" />
-
-        <android.support.design.widget.FloatingActionButton
-            android:id="@+id/fab"
-            android:layout_gravity="bottom|right"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_margin="@dimen/fab_padding"
-            android:src="@drawable/ic_fab_add"
-            android:scaleType="center"
-            android:elevation="6dp"
-            android:visibility="gone"
-            app:layout_anchor="@id/view_pager"
-            app:layout_anchorGravity="bottom|right"
-            app:backgroundTint="@color/color_primary"
-            app:fabSize="mini"
-            app:rippleColor="?colorAccent"/>
-
-    </android.support.design.widget.CoordinatorLayout>
+        android:layout_weight="1.0" />
 
     <FrameLayout
         android:id="@+id/transport_container"

--- a/src/musikdroid/app/src/main/res/layout/browse_fragment.xml
+++ b/src/musikdroid/app/src/main/res/layout/browse_fragment.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.design.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent" >
+
+    <android.support.design.widget.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:theme="@style/ThemeOverlay.AppCompat.Dark">
+
+        <android.support.v7.widget.Toolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            app:layout_scrollFlags="scroll|enterAlways|snap" />
+
+        <android.support.design.widget.TabLayout
+            android:id="@+id/tab_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@color/color_primary" />
+
+    </android.support.design.widget.AppBarLayout>
+
+    <android.support.v4.view.ViewPager
+        android:id="@+id/view_pager"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior" />
+
+    <android.support.design.widget.FloatingActionButton
+        android:id="@+id/fab"
+        android:layout_gravity="bottom|right"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="@dimen/fab_padding"
+        android:src="@drawable/ic_fab_add"
+        android:scaleType="center"
+        android:elevation="6dp"
+        android:visibility="gone"
+        app:layout_anchor="@id/view_pager"
+        app:layout_anchorGravity="bottom|right"
+        app:backgroundTint="@color/color_primary"
+        app:fabSize="mini"
+        app:rippleColor="?colorAccent"/>
+
+</android.support.design.widget.CoordinatorLayout>

--- a/src/musikdroid/app/src/main/res/layout/edit_playlist_activity.xml
+++ b/src/musikdroid/app/src/main/res/layout/edit_playlist_activity.xml
@@ -23,6 +23,7 @@
             app:layout_behavior="@string/appbar_scrolling_view_behavior" />
 
         <io.casey.musikcube.remote.ui.shared.view.EmptyListView
+            style="@style/EmptyView"
             android:id="@+id/empty_list_view"
             android:layout_width="match_parent"
             android:layout_height="match_parent"

--- a/src/musikdroid/app/src/main/res/layout/fragment_with_transport_activity.xml
+++ b/src/musikdroid/app/src/main/res/layout/fragment_with_transport_activity.xml
@@ -1,40 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <android.support.design.widget.CoordinatorLayout
-        android:layout_weight="1"
+    <FrameLayout
+        android:id="@+id/content_container"
         android:layout_width="match_parent"
-        android:layout_height="0dp">
-
-        <include layout="@layout/toolbar" />
-
-        <FrameLayout
-            android:id="@+id/content_container"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            app:layout_behavior="@string/appbar_scrolling_view_behavior" />
-
-        <android.support.design.widget.FloatingActionButton
-            android:id="@+id/fab"
-            android:layout_gravity="bottom|right"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_margin="@dimen/fab_padding"
-            android:src="@drawable/ic_fab_add"
-            android:scaleType="center"
-            android:elevation="6dp"
-            android:visibility="gone"
-            app:layout_anchor="@id/content_container"
-            app:layout_anchorGravity="bottom|right"
-            app:backgroundTint="@color/color_primary"
-            app:fabSize="mini"
-            app:rippleColor="?colorAccent"/>
-
-    </android.support.design.widget.CoordinatorLayout>
+        android:layout_height="0dp"
+        android:layout_weight="1" />
 
     <FrameLayout
         android:id="@+id/transport_container"

--- a/src/musikdroid/app/src/main/res/layout/recycler_view_activity.xml
+++ b/src/musikdroid/app/src/main/res/layout/recycler_view_activity.xml
@@ -30,20 +30,9 @@
             android:visibility="invisible"/>
 
         <android.support.design.widget.FloatingActionButton
+            style="@style/FAB"
             android:id="@+id/fab"
-            android:layout_gravity="bottom|right"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_margin="@dimen/fab_padding"
-            android:src="@drawable/ic_fab_add"
-            android:scaleType="center"
-            android:elevation="6dp"
-            android:visibility="gone"
-            app:layout_anchor="@id/recycler_view"
-            app:layout_anchorGravity="bottom|right"
-            app:backgroundTint="@color/color_primary"
-            app:fabSize="mini"
-            app:rippleColor="?colorAccent"/>
+            app:layout_anchor="@id/recycler_view" />
 
     </android.support.design.widget.CoordinatorLayout>
 

--- a/src/musikdroid/app/src/main/res/layout/recycler_view_activity.xml
+++ b/src/musikdroid/app/src/main/res/layout/recycler_view_activity.xml
@@ -3,7 +3,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:background="@color/theme_background" >
 
     <android.support.design.widget.CoordinatorLayout
         android:layout_weight="1"
@@ -23,6 +24,7 @@
             app:layout_behavior="@string/appbar_scrolling_view_behavior" />
 
         <io.casey.musikcube.remote.ui.shared.view.EmptyListView
+            style="@style/EmptyView"
             android:id="@+id/empty_list_view"
             android:layout_width="match_parent"
             android:layout_height="match_parent"

--- a/src/musikdroid/app/src/main/res/layout/recycler_view_with_empty_state.xml
+++ b/src/musikdroid/app/src/main/res/layout/recycler_view_with_empty_state.xml
@@ -4,6 +4,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:background="@color/theme_background"
     app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
     <com.simplecityapps.recyclerview_fastscroll.views.FastScrollRecyclerView
@@ -13,6 +14,7 @@
         android:layout_height="match_parent" />
 
     <io.casey.musikcube.remote.ui.shared.view.EmptyListView
+        style="@style/EmptyView"
         android:id="@+id/empty_list_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/src/musikdroid/app/src/main/res/layout/recycler_view_with_empty_state.xml
+++ b/src/musikdroid/app/src/main/res/layout/recycler_view_with_empty_state.xml
@@ -3,16 +3,14 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
     <com.simplecityapps.recyclerview_fastscroll.views.FastScrollRecyclerView
+        style="@style/RecyclerView"
         android:id="@+id/recycler_view"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        app:fastScrollAutoHide="true"
-        app:fastScrollAutoHideDelay="1500"
-        app:fastScrollThumbInactiveColor="@color/color_primary_dark"
-        app:fastScrollThumbColor="@color/color_accent" />
+        android:layout_height="match_parent" />
 
     <io.casey.musikcube.remote.ui.shared.view.EmptyListView
         android:id="@+id/empty_list_view"

--- a/src/musikdroid/app/src/main/res/layout/recycler_view_with_empty_state_and_toolbar_and_fab.xml
+++ b/src/musikdroid/app/src/main/res/layout/recycler_view_with_empty_state_and_toolbar_and_fab.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.design.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_weight="1"
+    android:layout_height="match_parent"
+    android:layout_width="match_parent">
+
+    <include layout="@layout/toolbar" />
+
+    <FrameLayout
+        android:id="@+id/content_container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+        <com.simplecityapps.recyclerview_fastscroll.views.FastScrollRecyclerView
+            style="@style/RecyclerView"
+            android:id="@+id/recycler_view"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+
+        <io.casey.musikcube.remote.ui.shared.view.EmptyListView
+            android:id="@+id/empty_list_view"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:visibility="invisible" />
+
+    </FrameLayout>
+
+    <android.support.design.widget.FloatingActionButton
+        style="@style/FAB"
+        android:id="@+id/fab"
+        app:layout_anchor="@id/content_container" />
+
+</android.support.design.widget.CoordinatorLayout>

--- a/src/musikdroid/app/src/main/res/layout/recycler_view_with_empty_state_and_toolbar_and_fab.xml
+++ b/src/musikdroid/app/src/main/res/layout/recycler_view_with_empty_state_and_toolbar_and_fab.xml
@@ -4,7 +4,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_weight="1"
     android:layout_height="match_parent"
-    android:layout_width="match_parent">
+    android:layout_width="match_parent"
+    android:background="@color/theme_background" >
 
     <include layout="@layout/toolbar" />
 
@@ -21,6 +22,7 @@
             android:layout_height="match_parent" />
 
         <io.casey.musikcube.remote.ui.shared.view.EmptyListView
+            style="@style/EmptyView"
             android:id="@+id/empty_list_view"
             android:layout_width="match_parent"
             android:layout_height="match_parent"

--- a/src/musikdroid/app/src/main/res/layout/transport_fragment.xml
+++ b/src/musikdroid/app/src/main/res/layout/transport_fragment.xml
@@ -46,7 +46,6 @@
 
     </LinearLayout>
 
-
     <android.support.v4.widget.Space
         android:layout_width="0dp"
         android:layout_height="2dp"/>
@@ -87,6 +86,5 @@
         </LinearLayout>
 
     </FrameLayout>
-
 
 </LinearLayout>

--- a/src/musikdroid/app/src/main/res/values/styles.xml
+++ b/src/musikdroid/app/src/main/res/values/styles.xml
@@ -87,4 +87,26 @@
         <item name="android:shadowRadius">3</item>
     </style>
 
+    <style name="FAB">
+        <item name="android:layout_gravity">bottom|right</item>
+        <item name="android:layout_width">wrap_content</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:layout_margin">@dimen/fab_padding</item>
+        <item name="android:src">@drawable/ic_fab_add</item>
+        <item name="android:scaleType">center</item>
+        <item name="android:elevation">6dp</item>
+        <item name="android:visibility">gone</item>
+        <item name="layout_anchorGravity">bottom|right</item>
+        <item name="backgroundTint">@color/color_primary</item>
+        <item name="fabSize">mini</item>
+        <item name="rippleColor">?colorAccent</item>
+    </style>
+
+    <style name="RecyclerView">
+        <item name="fastScrollAutoHide">true</item>
+        <item name="fastScrollAutoHideDelay">1500</item>
+        <item name="fastScrollThumbInactiveColor">@color/color_primary_dark</item>
+        <item name="fastScrollThumbColor">@color/color_accent</item>
+    </style>
+
 </resources>

--- a/src/musikdroid/app/src/main/res/values/styles.xml
+++ b/src/musikdroid/app/src/main/res/values/styles.xml
@@ -109,4 +109,8 @@
         <item name="fastScrollThumbColor">@color/color_accent</item>
     </style>
 
+    <style name="EmptyView">
+        <item name="android:background">@color/theme_background</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
This set of changes explores using Fragments more prevalently -- this way we can re-use a single `TransportFragment` in the tabbed browse experience, without pushing new instances to the screen. This makes for a better user experience at the cost of a bunch of annoying book keeping. 