### PR TITLE
Fix missing md5.c in CMakeLists

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -56,6 +56,7 @@ set(CORE_SOURCES
   ../3rdparty/src/sqlite/sqlite3.c
   ../3rdparty/src/kiss_fft.c
   ../3rdparty/src/kiss_fftr.c
+  ../3rdparty/src/md5.c
 )
 
 include_directories(


### PR DESCRIPTION
In commit 9bbd1f01405578d8fa73705aa22a88c7219f0856 "Removed LibreSSL..." the files md5.h, md5.c were added to the source code and VS build system but not in CMakeLists. This led to linker errors while building on my linux machine.