### PR TITLE
added chocolatey install options on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ on freebsd musikcube can be installed as follows:
 
 - `pkg install musikcube`
 
+on windows, you can install via chocolatey:
+
+- `choco install musikcube`
+
+then run using shell, Win+R dialog or by typing in Start Menu `musikcube` or `mcube`.
+
 # raspberry pi
 
 musikcube runs well on a raspberry pi, connected to you home stereo. [see here for detailed setup instructions](https://github.com/clangen/musikcube/wiki/raspberry-pi).


### PR DESCRIPTION
Hi, 

I created chocolatey package for Windows. You can test it with `cinst musikcube --version 0.65.0`. All future versions will be there since current one and could be installed with `--version` parameter.

The package is automatic and will be up to date always, with up to few hours latency.

https://chocolatey.org/packages/musikcube
Source: https://github.com/majkinetor/au-packages/tree/master/musikcube