### PR TITLE
Unbreak build with Boost < 1.72

### DIFF
--- a/src/core/audio/Stream.h
+++ b/src/core/audio/Stream.h
@@ -41,6 +41,7 @@
 #include <core/sdk/IDecoder.h>
 #include <core/sdk/IDSP.h>
 
+#include <deque>
 #include <list>
 
 namespace musik { namespace core { namespace audio {


### PR DESCRIPTION
Regressed by boostorg/filesystem@9a14c37d6f95. See [error log](https://github.com/clangen/musikcube/files/3772350/musikcube-0.65.1_3.log).