### PR TITLE
FfmpegDecoder refactor to fix bugs and remove usage of deprecated APIs

### DIFF
--- a/src/core/audio/GaplessTransport.cpp
+++ b/src/core/audio/GaplessTransport.cpp
@@ -338,7 +338,10 @@ void GaplessTransport::OnPlayerFinished(Player* player) {
     }
 
     if (stopped) {
-        this->Stop();
+        /* note we call through to StopInternal() because we don't
+        want to stop the output immediately, it may still have some
+        trailing samples queued up */
+        this->StopInternal(false, false);
     }
 }
 

--- a/src/plugins/ffmpegdecoder/FfmpegDecoder.cpp
+++ b/src/plugins/ffmpegdecoder/FfmpegDecoder.cpp
@@ -291,7 +291,7 @@ bool FfmpegDecoder::Open(musik::core::sdk::IDataStream *stream) {
                 if (avformat_open_input(&this->formatContext, "", nullptr, nullptr) == 0) {
                     if (avformat_find_stream_info(this->formatContext, nullptr) >= 0) {
                         for (unsigned i = 0; i < this->formatContext->nb_streams; i++) {
-                            if (this->formatContext->streams[i]->codec->codec_type == AVMEDIA_TYPE_AUDIO) {
+                            if (this->formatContext->streams[i]->codecpar->codec_type == AVMEDIA_TYPE_AUDIO) {
                                 this->streamId = (int)i;
                                 break;
                             }
@@ -321,8 +321,8 @@ bool FfmpegDecoder::Open(musik::core::sdk::IDataStream *stream) {
                         }
 
                         auto stream = this->formatContext->streams[this->streamId];
-                        this->rate = stream->codec->sample_rate;
-                        this->channels = stream->codec->channels;
+                        this->rate = stream->codecpar->sample_rate;
+                        this->channels = stream->codecpar->channels;
                         this->duration = (double) this->formatContext->duration / (double) AV_TIME_BASE;
 
                         this->preferredFrameSize = this->codecContext->frame_size ? this->codecContext->frame_size : DEFAULT_FRAME_SIZE;

--- a/src/plugins/ffmpegdecoder/FfmpegDecoder.cpp
+++ b/src/plugins/ffmpegdecoder/FfmpegDecoder.cpp
@@ -391,6 +391,9 @@ bool FfmpegDecoder::ReadSendAndReceivePacket(AVPacket& packet) {
             }
         }
     }
+    else {
+        logAvError("av_codec_send_packet", error);
+    }
     return decodedAtLeastOneFrame;
 }
 
@@ -443,7 +446,8 @@ bool FfmpegDecoder::DrainResamplerToFifoQueue() {
 bool FfmpegDecoder::RefillFifoQueue() {
     bool sentAtLeastOnePacket = false;
     bool readFailed = false;
-    while (!readFailed && av_audio_fifo_size(this->outputFifo) < this->preferredFrameSize) {
+    int fifoSize = av_audio_fifo_size(this->outputFifo);
+    while (!readFailed && fifoSize < this->preferredFrameSize) {
         AVPacket packet;
         av_init_packet(&packet);
         packet.data = nullptr;
@@ -457,6 +461,7 @@ bool FfmpegDecoder::RefillFifoQueue() {
             readFailed = true;
         }
         av_free_packet(&packet);
+        fifoSize = av_audio_fifo_size(this->outputFifo);
     }
     return sentAtLeastOnePacket;
 }

--- a/src/plugins/ffmpegdecoder/FfmpegDecoder.h
+++ b/src/plugins/ffmpegdecoder/FfmpegDecoder.h
@@ -69,6 +69,7 @@ class FfmpegDecoder: public musik::core::sdk::IDecoder {
         void Reset();
         AVFrame* ReallocFrame(AVFrame* original, AVSampleFormat format, int samplesPerChannel, int sampleRate);
         bool ReadFromFifoAndWriteToBuffer(IBuffer* buffer, bool drain);
+        bool InitializeResampler(IBuffer* buffer);
 
         musik::core::sdk::IDataStream* stream;
         AVIOContext* ioContext;
@@ -76,6 +77,7 @@ class FfmpegDecoder: public musik::core::sdk::IDecoder {
         AVFormatContext* formatContext;
         AVCodecContext* codecContext;
         AVFrame* decodedFrame;
+        AVFrame* resampledFrame;
         SwrContext* resampler;
         unsigned char* buffer;
         size_t bufferSize;

--- a/src/plugins/ffmpegdecoder/FfmpegDecoder.h
+++ b/src/plugins/ffmpegdecoder/FfmpegDecoder.h
@@ -43,6 +43,7 @@ extern "C" {
     #include <libavformat/avformat.h>
     #include <libavcodec/avcodec.h>
     #include <libavutil/samplefmt.h>
+    #include <libavutil/audio_fifo.h>
     #include <libswresample/swresample.h>
 }
 
@@ -66,13 +67,14 @@ class FfmpegDecoder: public musik::core::sdk::IDecoder {
 
     private:
         void Reset();
+        AVFrame* ReallocFrame(AVFrame* original, AVSampleFormat format, int samplesPerChannel, int sampleRate);
+        bool ReadFromFifoAndWriteToBuffer(IBuffer* buffer, bool drain);
 
-    private:
         musik::core::sdk::IDataStream* stream;
         AVIOContext* ioContext;
+        AVAudioFifo* outputFifo;
         AVFormatContext* formatContext;
         AVCodecContext* codecContext;
-        AVPacket packet;
         AVFrame* decodedFrame;
         SwrContext* resampler;
         unsigned char* buffer;

--- a/src/plugins/ffmpegdecoder/FfmpegDecoder.h
+++ b/src/plugins/ffmpegdecoder/FfmpegDecoder.h
@@ -68,8 +68,12 @@ class FfmpegDecoder: public musik::core::sdk::IDecoder {
     private:
         void Reset();
         AVFrame* ReallocFrame(AVFrame* original, AVSampleFormat format, int samplesPerChannel, int sampleRate);
+        bool RefillFifoQueue();
+        bool DrainResamplerToFifoQueue();
         bool ReadFromFifoAndWriteToBuffer(IBuffer* buffer, bool drain);
         bool InitializeResampler(IBuffer* buffer);
+        bool ReadSendAndReceivePacket(AVPacket& packet);
+        void FlushAndFinalizeDecoder();
 
         musik::core::sdk::IDataStream* stream;
         AVIOContext* ioContext;
@@ -83,6 +87,8 @@ class FfmpegDecoder: public musik::core::sdk::IDecoder {
         size_t bufferSize;
         size_t rate, channels;
         int streamId;
+        int preferredFrameSize;
         double duration;
         bool exhausted{false};
+        bool eof{false};
 };

--- a/src/plugins/ffmpegdecoder/FfmpegDecoder.h
+++ b/src/plugins/ffmpegdecoder/FfmpegDecoder.h
@@ -67,7 +67,7 @@ class FfmpegDecoder: public musik::core::sdk::IDecoder {
 
     private:
         void Reset();
-        AVFrame* AllocFrame(AVFrame* original, AVSampleFormat format, int sampleRate);
+        AVFrame* AllocFrame(AVFrame* original, AVSampleFormat format, int sampleRate, int frameSize = -1);
         bool RefillFifoQueue();
         bool DrainResamplerToFifoQueue();
         bool ReadFromFifoAndWriteToBuffer(IBuffer* buffer);

--- a/src/plugins/ffmpegdecoder/FfmpegDecoder.h
+++ b/src/plugins/ffmpegdecoder/FfmpegDecoder.h
@@ -67,12 +67,12 @@ class FfmpegDecoder: public musik::core::sdk::IDecoder {
 
     private:
         void Reset();
-        AVFrame* ReallocFrame(AVFrame* original, AVSampleFormat format, int samplesPerChannel, int sampleRate);
+        AVFrame* AllocFrame(AVFrame* original, AVSampleFormat format, int sampleRate);
         bool RefillFifoQueue();
         bool DrainResamplerToFifoQueue();
-        bool ReadFromFifoAndWriteToBuffer(IBuffer* buffer, bool drain);
+        bool ReadFromFifoAndWriteToBuffer(IBuffer* buffer);
         bool InitializeResampler(IBuffer* buffer);
-        bool ReadSendAndReceivePacket(AVPacket& packet);
+        bool ReadSendAndReceivePacket(AVPacket* packet);
         void FlushAndFinalizeDecoder();
 
         musik::core::sdk::IDataStream* stream;
@@ -84,11 +84,11 @@ class FfmpegDecoder: public musik::core::sdk::IDecoder {
         AVFrame* resampledFrame;
         SwrContext* resampler;
         unsigned char* buffer;
-        size_t bufferSize;
-        size_t rate, channels;
+        int bufferSize;
+        int rate, channels;
         int streamId;
         int preferredFrameSize;
         double duration;
-        bool exhausted{false};
-        bool eof{false};
+        bool exhausted{ false };
+        bool eof{ false };
 };

--- a/src/plugins/ffmpegdecoder/ffmpegdecoder.vcxproj
+++ b/src/plugins/ffmpegdecoder/ffmpegdecoder.vcxproj
@@ -92,7 +92,7 @@
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>3rdparty/include;3rdparty/win32_include;../../3rdparty/win32_include;../../../../boost_1_71_0;../../;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN32;WIN32_LEAN_AND_MEAN;NOMINMAX;ZLIB_WINAPI;MHD_W32LIB;BUILDING_MHD_LIB;_SCL_SECURE_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;WIN32_LEAN_AND_MEAN;NOMINMAX;_SCL_SECURE_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <DisableSpecificWarnings>4996</DisableSpecificWarnings>
     </ClCompile>
@@ -110,7 +110,7 @@
       <Optimization>Disabled</Optimization>
       <SDLCheck>false</SDLCheck>
       <AdditionalIncludeDirectories>3rdparty/include;3rdparty/win32_include;../../3rdparty/win32_include;../../../../boost_1_71_0;../../;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN32;WIN32_LEAN_AND_MEAN;NOMINMAX;_SCL_SECURE_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;WIN32_LEAN_AND_MEAN;NOMINMAX;_SCL_SECURE_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
@@ -126,7 +126,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>3rdparty/include;3rdparty/win32_include;../../3rdparty/win32_include;../../../../boost_1_71_0;../../;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN32;WIN32_LEAN_AND_MEAN;NOMINMAX;ZLIB_WINAPI;MHD_W32LIB;BUILDING_MHD_LIB;_SCL_SECURE_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;WIN32_LEAN_AND_MEAN;NOMINMAX;_SCL_SECURE_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <DebugInformationFormat>None</DebugInformationFormat>
       <InlineFunctionExpansion>Default</InlineFunctionExpansion>
@@ -155,7 +155,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>false</SDLCheck>
       <AdditionalIncludeDirectories>3rdparty/include;3rdparty/win32_include;../../3rdparty/win32_include;../../../../boost_1_71_0;../../;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN32;WIN32_LEAN_AND_MEAN;NOMINMAX;_SCL_SECURE_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;WIN32_LEAN_AND_MEAN;NOMINMAX;_SCL_SECURE_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>

--- a/src/plugins/ffmpegdecoder/plugin.cpp
+++ b/src/plugins/ffmpegdecoder/plugin.cpp
@@ -67,7 +67,7 @@ class FfmpegPlugin : public musik::core::sdk::IPlugin {
         FfmpegPlugin() { }
         virtual void Release() { };
         virtual const char* Name() { return "ffmpeg IDecoder"; }
-        virtual const char* Version() { return "0.1.0"; }
+        virtual const char* Version() { return "0.7.0"; }
         virtual const char* Author() { return "clangen"; }
         virtual const char* Guid() { return "f993ec34-ab43-4c6a-9a0a-6462b4ae1a1c"; }
         virtual bool Configurable() { return false; }
@@ -82,7 +82,6 @@ class FfmpegDecoderFactory : public musik::core::sdk::IDecoderFactory {
 #ifdef WIN32
             CoInitializeEx(nullptr, COINIT_MULTITHREADED);
 #endif
-            av_register_all();
 
             typeToCodecId = {
                 { ".mp3", AV_CODEC_ID_MP3 },
@@ -110,13 +109,15 @@ class FfmpegDecoderFactory : public musik::core::sdk::IDecoderFactory {
                 { ".wv", AV_CODEC_ID_WAVPACK },
             };
 
-            AVCodec* codec = av_codec_next(nullptr);
-            while (codec != nullptr) {
-                const AVCodecDescriptor* descriptor = avcodec_descriptor_get(codec->id);
-                if (descriptor != nullptr && descriptor->type == AVMEDIA_TYPE_AUDIO) {
-                    supported.insert(descriptor->id);
+            const AVCodec* codec = nullptr;
+            void *i = 0;
+            while ((codec = av_codec_iterate(&i))) {
+                if (av_codec_is_decoder(codec)) {
+                    const AVCodecDescriptor* descriptor = avcodec_descriptor_get(codec->id);
+                    if (descriptor != nullptr && descriptor->type == AVMEDIA_TYPE_AUDIO) {
+                        supported.insert(descriptor->id);
+                    }
                 }
-                codec = av_codec_next(codec);
             }
         }
 

--- a/src/plugins/stockencoders/FfmpegEncoder.cpp
+++ b/src/plugins/stockencoders/FfmpegEncoder.cpp
@@ -324,7 +324,7 @@ bool FfmpegEncoder::OpenOutputCodec(size_t rate, size_t channels, size_t bitrate
     }
 
     /* fifo buffer that will be used by the encoder */
-    this->outputFifo = av_audio_fifo_alloc(AV_SAMPLE_FMT_FLT, channels, 1);
+    this->outputFifo = av_audio_fifo_alloc(AV_SAMPLE_FMT_FLT, (int) channels, 1);
 
     if (!this->outputFifo) {
         logError("av_audio_fifo_alloc");
@@ -355,8 +355,8 @@ bool FfmpegEncoder::Initialize(IDataStream* out, size_t rate, size_t channels, s
     if (this->OpenOutputContext()) {
         if (this->OpenOutputCodec(rate, channels, bitrate)) {
             if (this->WriteOutputHeader()) {
-                this->inputChannelCount = channels;
-                this->inputSampleRate = rate;
+                this->inputChannelCount = (int) channels;
+                this->inputSampleRate = (int) rate;
                 this->isValid = true;
             }
         }
@@ -578,7 +578,7 @@ void FfmpegEncoder::FlushResampler() {
         this->resampledFrame = this->ReallocFrame(
             this->resampledFrame,
             this->outputContext->sample_fmt,
-            FFMIN(bufferedFrames, this->outputContext->frame_size),
+            FFMIN((int) bufferedFrames, this->outputContext->frame_size),
             this->outputContext->sample_rate);
 
         int converted = swr_convert(

--- a/src/plugins/stockencoders/FfmpegEncoder.cpp
+++ b/src/plugins/stockencoders/FfmpegEncoder.cpp
@@ -418,7 +418,7 @@ bool FfmpegEncoder::Encode(const IBuffer* pcm) {
         return false;
     }
 
-    if (this->ResampleAndWriteToFifo(pcm)) {
+    if (this->WriteSamplesToFifo(pcm)) {
         if (this->ReadFromFifoAndWriteToOutput(false)) {
             return true;
         }
@@ -452,7 +452,7 @@ bool FfmpegEncoder::WriteOutputHeader() {
     return true;
 }
 
-bool FfmpegEncoder::ResampleAndWriteToFifo(const IBuffer* pcm) {
+bool FfmpegEncoder::WriteSamplesToFifo(const IBuffer* pcm) {
     const int totalSamples = pcm->Samples();
     const int samplesPerChannel = totalSamples / pcm->Channels();
     const uint8_t* inData = (const uint8_t*) pcm->BufferPointer();

--- a/src/plugins/stockencoders/FfmpegEncoder.h
+++ b/src/plugins/stockencoders/FfmpegEncoder.h
@@ -64,7 +64,7 @@ class FfmpegEncoder : public musik::core::sdk::IBlockingEncoder {
         bool OpenOutputContext();
         bool WriteOutputHeader();
         bool WriteOutputTrailer();
-        bool ResampleAndWriteToFifo(const IBuffer* pcm);
+        bool WriteSamplesToFifo(const IBuffer* pcm);
         bool ReadFromFifoAndWriteToOutput(bool drain);
         void FlushResampler();
         AVFrame* ReallocFrame(AVFrame* original, AVSampleFormat format, int samplesPerChannel, int sampleRate);

--- a/src/plugins/stockencoders/main.cpp
+++ b/src/plugins/stockencoders/main.cpp
@@ -85,7 +85,7 @@ static class Plugin : public IPlugin {
 
         virtual void Release() { }
         virtual const char* Name() { return "Stock Encoders (MP3, OGG)"; }
-        virtual const char* Version() { return "0.6.0"; }
+        virtual const char* Version() { return "0.7.0"; }
         virtual const char* Author() { return "clangen"; }
         virtual const char* Guid() { return "d4d13803-a285-4481-ad1e-106131e0d523"; }
         virtual bool Configurable() { return false; }


### PR DESCRIPTION
Seems to be working, ~but stress testing with `NullOutput` suggests there's a small memory leak somewhere that I haven't yet figured out.~

Edit: memory usage over a long period of time actually appeared to be quite low and asymptotic, which leads me to believe what I was observing was due to slow fragmentation. Older release builds also exhibit the same behavior. I think we're fine.