### PR TITLE
musikcube port to OpenBSD 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ link_directories ("${musikcube_SOURCE_DIR}/bin/plugins")
 
 set(COMMON_LINK_LIBS ${BOOST_LINK_LIBS} curl pthread crypto)
 
-if (CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
+if (CMAKE_SYSTEM_NAME MATCHES "FreeBSD" OR CMAKE_SYSTEM_NAME MATCHES "OpenBSD")
   set (musikcube_LINK_LIBS ${COMMON_LINK_LIBS})
 else()
   set (musikcube_LINK_LIBS ${COMMON_LINK_LIBS} dl)
@@ -79,7 +79,7 @@ endif()
 
 # "/usr/local" doesn't seem to be included by default on macOS 10.12+
 # "/opt/local" is the default installation location for MacPorts
-if (CMAKE_SYSTEM_NAME MATCHES "Darwin" OR CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
+if (CMAKE_SYSTEM_NAME MATCHES "Darwin" OR CMAKE_SYSTEM_NAME MATCHES "FreeBSD" OR CMAKE_SYSTEM_NAME MATCHES "OpenBSD")
   link_directories ("/usr/local/lib")
   link_directories ("/usr/local/opt/openssl/lib")
   include_directories("/usr/local/include")
@@ -88,7 +88,7 @@ endif ()
 
 if (EXISTS "/etc/arch-release" OR EXISTS "/etc/manjaro-release" OR NO_NCURSESW)
   add_definitions (-DNO_NCURSESW)
-elseif(CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
+elseif(CMAKE_SYSTEM_NAME MATCHES "FreeBSD" OR CMAKE_SYSTEM_NAME MATCHES "OpenBSD" )
   add_definitions (-DNO_NCURSESW)
 endif()
 
@@ -192,6 +192,13 @@ if (CMAKE_SYSTEM_NAME MATCHES "Linux")
   if (${ENABLE_SNDIO} MATCHES "true")
     add_subdirectory(src/plugins/sndioout)
     add_dependencies(musikcube sndioout)
+  endif()
+elseif (CMAKE_SYSTEM_NAME MATCHES "OpenBSD")
+  add_subdirectory(src/plugins/sndioout)
+  add_dependencies(musikcube sndioout)
+  if (${ENABLE_PULSEAUDIO} MATCHES "true")
+    add_subdirectory(src/plugins/pulseout) # disabled by default
+    add_dependencies(musikcube pulseout)
   endif()
 elseif (CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
   add_subdirectory(src/plugins/sndioout)

--- a/src/core/sdk/HttpClient.h
+++ b/src/core/sdk/HttpClient.h
@@ -126,6 +126,8 @@ namespace musik { namespace core { namespace sdk {
         static const std::string PLATFORM = "macos";
 #elif defined __FreeBSD__
         static const std::string PLATFORM = "freebsd";
+#elif defined __OpenBSD__
+        static const std::string PLATFORM = "openbsd";
 #else
         static const std::string PLATFORM = "linux";
 #endif

--- a/src/core/support/Common.cpp
+++ b/src/core/support/Common.cpp
@@ -56,6 +56,15 @@
     #include <limits.h>
 #endif
 
+// given the #ifdef/#else above, the following is not required.
+// Nor it is the #if FreeBSD below. 
+#ifdef __OpenBSD__
+	#include <sys/types.h>
+	#include <sys/sysctl.h>
+	#include <unistd.h>
+	#include <limits.h>
+#endif
+
 #ifdef __FreeBSD__
     #include <sys/types.h>
     #include <sys/sysctl.h>
@@ -125,15 +134,29 @@ namespace musik { namespace core {
                 mib[3] = -1;
                 size_t bufsize = sizeof(pathbuf);
                 sysctl(mib, 4, pathbuf, &bufsize, nullptr, 0);
-            #else
-                std::string pathToProc = u8fmt("/proc/%d/exe", (int) getpid());
-                readlink(pathToProc.c_str(), pathbuf, PATH_MAX);
-	    #endif
+            #elif defined  __OpenBSD__
+			    int mib[4];
+			    char **argv;
+			    size_t len = ARG_MAX;
+
+			    mib[0] = CTL_KERN;
+			    mib[1] = KERN_PROC_ARGS;
+			    mib[2] = getpid();
+			    mib[3] = KERN_PROC_ARGV;
+
+			    argv = new char*[len];
+			    if (sysctl(mib, 4, argv, &len, nullptr, 0) < 0) abort();
+
+			    boost::filesystem::path command = boost::filesystem::system_complete(argv[0]);
+			    realpath(command.c_str(), pathbuf);
+			    delete[] argv;
+	        #endif
 
             result.assign(pathbuf);
             size_t last = result.find_last_of("/");
             result = result.substr(0, last); /* remove filename component */
         #endif
+        std::cout << result << std::endl;
 
         return result;
     }

--- a/src/core/support/Common.cpp
+++ b/src/core/support/Common.cpp
@@ -150,7 +150,10 @@ namespace musik { namespace core {
 			    boost::filesystem::path command = boost::filesystem::system_complete(argv[0]);
 			    realpath(command.c_str(), pathbuf);
 			    delete[] argv;
-	        #endif
+            #else
+                std::string pathToProc = u8fmt("/proc/%d/exe", (int) getpid());
+                readlink(pathToProc.c_str(), pathbuf, PATH_MAX);
+	    #endif
 
             result.assign(pathbuf);
             size_t last = result.find_last_of("/");

--- a/src/core/support/Common.cpp
+++ b/src/core/support/Common.cpp
@@ -156,7 +156,6 @@ namespace musik { namespace core {
             size_t last = result.find_last_of("/");
             result = result.substr(0, last); /* remove filename component */
         #endif
-        std::cout << result << std::endl;
 
         return result;
     }

--- a/src/musikcube/app/util/UpdateCheck.cpp
+++ b/src/musikcube/app/util/UpdateCheck.cpp
@@ -66,6 +66,8 @@ static const std::string PLATFORM = "win32";
 static const std::string PLATFORM = "macos";
 #elif defined __FreeBSD__
 static const std::string PLATFORM = "freebsd";
+#elif defined __OpenBSD__
+static const std::string PLATFORM = "openbsd";
 #else
 static const std::string PLATFORM = "linux";
 #endif

--- a/src/musikcube/app/version.h
+++ b/src/musikcube/app/version.h
@@ -49,6 +49,8 @@ namespace musik {
             static const std::string PLATFORM = "macos";
 #elif defined __FreeBSD__
             static const std::string PLATFORM = "freebsd";
+#elif defined __OpenBSD__
+            static const std::string PLATFORM = "openbsd";
 #else
             static const std::string PLATFORM = "linux";
 #endif


### PR DESCRIPTION
musikcube can be compiled and installed on OpenBSD with:
doas pkg_add cmake boost libogg libvorbis ffmpeg curl libmicrohttpd lame libev taglib
cmake .
make
doas make install

The port to OpenBSD is mostly trivially adapted from the various FreeBSD #ifdefs with the substitution FreeBSD -> OpenBSD.
In the file src/musikcube/app/util/UpdateCheck.cpp, FreeBSD retrieves the app's directory with a syscall to KERN_PROC_PATHNAME, which does not exist in OpenBSD.
My solution is to use a syscall to retrieve ARGV[0] and pass it to boost::filesystem::system_complete() to get the the full path.
I tested this against both with the installed executable and with a malformed path like
./musikcube/../../../home/luca/musikcube/bin/musikcube
