### PR TITLE
escape percent signs so wprintw won't replace them with random things

### DIFF
--- a/src/musikcube/app/window/TransportWindow.cpp
+++ b/src/musikcube/app/window/TransportWindow.cpp
@@ -304,6 +304,14 @@ static size_t writePlayingFormat(
             }
         }
 
+        /* any % in the value string might be parsed by wprintw, so replace it */
+        std::size_t percentSignIndex = value.find("%");
+        while (percentSignIndex != std::string::npos) {
+            value.replace(percentSignIndex, 1, "%%");
+            /* we replaced one % with 2 of them, so we need to skip ahead 2 chars */
+            percentSignIndex = value.find("%", percentSignIndex + 2);
+        }
+
         ON(w, attr);
         checked_wprintw(w, value.c_str());
         OFF(w, attr);


### PR DESCRIPTION
I have an album named `1 0 0 % E X T R A C T` which would result in the following in the now playing bar
![adgadg](https://user-images.githubusercontent.com/1922630/75989324-58512c00-5ef3-11ea-9a32-b82508fccfc9.png)
everywhere else it displays correctly

my hunch was that it's being used as format placeholder, so I added code to replace every single `%` in user values with 2 of them! which seems to work :)

![bettterr](https://user-images.githubusercontent.com/1922630/75989491-a5350280-5ef3-11ea-871b-d1cf40c1b93d.png)

