### PR TITLE
Use pkg-config for pipewire library in cmake

### DIFF
--- a/src/plugins/pipewireout/CMakeLists.txt
+++ b/src/plugins/pipewireout/CMakeLists.txt
@@ -7,10 +7,8 @@ ensure_library_exists(pipewire-0.3)
 
 message(STATUS "[pipewireout] plugin enabled")
 
-include_directories("/usr/include/spa-0.2")
-include_directories("/usr/local/include/spa-0.2")
-include_directories("/usr/include/pipewire-0.3")
-include_directories("/usr/local/include/pipewire-0.3")
+find_package(PkgConfig)
+pkg_check_modules(PIPEWIRE REQUIRED IMPORTED_TARGET libpipewire-0.3)
 
 add_library(pipewireout SHARED ${pipewireout_SOURCES})
-target_link_libraries(pipewireout ${musikcube_LINK_LIBS} pipewire-0.3)
+target_link_libraries(pipewireout ${musikcube_LINK_LIBS} PkgConfig::PIPEWIRE)


### PR DESCRIPTION
Currently you're using hardcoded paths which are not always correct when e.g. cross-compiling for a different architecture

See e.g. here

https://github.com/void-linux/void-packages/runs/2380635818#step:8:555

This patch makes it use pkg-config to discover all needed files and headers