### PR TITLE
Build: ensure static library existence only when needed

### DIFF
--- a/src/plugins/flacdecoder/CMakeLists.txt
+++ b/src/plugins/flacdecoder/CMakeLists.txt
@@ -6,12 +6,12 @@ set (flacdecoder_SOURCES
 )
 
 ensure_library_exists(FLAC)
-ensure_library_exists(libFLAC.a)
 
 add_library(flacdecoder SHARED ${flacdecoder_SOURCES})
 
 # prefer static libraries on mac to make redist easier
 if (${LINK_STATICALLY} MATCHES "true")
+  ensure_library_exists(libFLAC.a)
   find_library(FLACLIB NAMES libFLAC.a FLAC)
   find_library(OGGLIB NAMES libogg.a ogg)
   target_link_libraries(flacdecoder ${musikcube_LINK_LIBS} ${FLACLIB} ${OGGLIB})

--- a/src/plugins/m4adecoder/CMakeLists.txt
+++ b/src/plugins/m4adecoder/CMakeLists.txt
@@ -17,12 +17,12 @@ include_directories(
 )
 
 ensure_library_exists(faad)
-ensure_library_exists(libfaad.a)
 
 add_library(m4adecoder SHARED ${m4adecoder_SOURCES})
 
 # prefer static libraries on mac to make redist easier
 if (${LINK_STATICALLY} MATCHES "true")
+  ensure_library_exists(libfaad.a)
   find_library(FAADLIB NAMES libfaad.a faad)
   target_link_libraries(m4adecoder ${musikcube_LINK_LIBS} ${FAADLIB})
 else()

--- a/src/plugins/oggdecoder/CMakeLists.txt
+++ b/src/plugins/oggdecoder/CMakeLists.txt
@@ -6,16 +6,16 @@ set (oggdecoder_SOURCES
 )
 
 ensure_library_exists(ogg)
-ensure_library_exists(libogg.a)
 ensure_library_exists(vorbis)
-ensure_library_exists(libvorbis.a)
 ensure_library_exists(vorbisfile)
-ensure_library_exists(libvorbisfile.a)
 
 add_library(oggdecoder SHARED ${oggdecoder_SOURCES})
 
 # prefer static libraries on mac to make redist easier
 if (${LINK_STATICALLY} MATCHES "true")
+    ensure_library_exists(libogg.a)
+    ensure_library_exists(libvorbisfile.a)
+    ensure_library_exists(libvorbis.a)
     find_library(OGGLIB NAMES libogg.a ogg)
     find_library(VORBISLIB NAMES libvorbis.a vorbis)
     find_library(VORBISFILELIB NAMES libvorbisfile.a vorbisfile)


### PR DESCRIPTION
The current cmake build script for flac, m4a and ogg asserts the corresponding library existence. However, when building in environments like buildroot, the static library may not exist. Thus only check for them when static build is actually needed.