### PR TITLE
Fix album duration calculation off-by-one

### DIFF
--- a/src/musikcore/library/query/CategoryTrackListQuery.cpp
+++ b/src/musikcore/library/query/CategoryTrackListQuery.cpp
@@ -176,11 +176,12 @@ void CategoryTrackListQuery::ProcessResult(musik::core::db::Statement& trackQuer
     std::string lastAlbum;
     size_t index = 0;
     size_t lastHeaderIndex = 0;
+    size_t trackDuration = 0;
     size_t runningDuration = 0;
 
     while (trackQuery.Step() == Row) {
         const int64_t id = trackQuery.ColumnInt64(0);
-        runningDuration += trackQuery.ColumnInt32(1);
+        trackDuration = trackQuery.ColumnInt32(1);
         std::string album = trackQuery.ColumnText(2);
 
         if (this->parseHeaders && album != lastAlbum) {
@@ -193,6 +194,8 @@ void CategoryTrackListQuery::ProcessResult(musik::core::db::Statement& trackQuer
             headers->insert(index);
             lastAlbum = album;
         }
+
+        runningDuration += trackDuration;
 
         result->Add(id);
         ++index;

--- a/src/musikcore/library/query/DirectoryTrackListQuery.cpp
+++ b/src/musikcore/library/query/DirectoryTrackListQuery.cpp
@@ -84,11 +84,13 @@ bool DirectoryTrackListQuery::OnRun(Connection& db) {
 
     std::string lastAlbum;
     size_t lastHeaderIndex = 0;
+    size_t trackDuration = 0;
     size_t runningDuration = 0;
     size_t index = 0;
+
     while (select.Step() == db::Row) {
         const int64_t id = select.ColumnInt64(0);
-        runningDuration += select.ColumnInt32(1);
+        trackDuration = select.ColumnInt32(1);
         std::string album = select.ColumnText(2);
 
         if (!album.size()) {
@@ -104,6 +106,8 @@ bool DirectoryTrackListQuery::OnRun(Connection& db) {
             headers->insert(index);
             lastAlbum = album;
         }
+
+        runningDuration += trackDuration;
 
         result->Add(id);
         ++index;

--- a/src/musikcore/library/query/SearchTrackListQuery.cpp
+++ b/src/musikcore/library/query/SearchTrackListQuery.cpp
@@ -159,11 +159,12 @@ bool SearchTrackListQuery::OnRun(Connection& db) {
     std::string lastAlbum;
     size_t index = 0;
     size_t lastHeaderIndex = 0;
+    size_t trackDuration = 0;
     size_t runningDuration = 0;
 
     while (trackQuery.Step() == Row) {
         const int64_t id = trackQuery.ColumnInt64(0);
-        runningDuration += trackQuery.ColumnInt32(1);
+        trackDuration = trackQuery.ColumnInt32(1);
         std::string album = trackQuery.ColumnText(2);
 
         if (!album.size()) {
@@ -180,6 +181,8 @@ bool SearchTrackListQuery::OnRun(Connection& db) {
             headers->insert(index);
             lastAlbum = album;
         }
+
+        runningDuration += trackDuration;
 
         result->Add(id);
         ++index;


### PR DESCRIPTION
This PR resolves #428. A shorter fix could have been made by moving `runningDuration += trackQuery.ColumnInt32(1)` down below the `if (album != lastAlbum) {...}` blocks but I decided against it for code clarity.

Tested on:
- Windows 10 1904, compiled against `boost_1_74_0` as instructed [for building on Windows](https://github.com/clangen/musikcube/wiki/building#windows) on "Release-Win | x64" option. Confirmed fixed.
- KDE neon 5.22.4 (based on Ubuntu 20.04), compiled against dependencies as instructed [for building on Ubuntu](https://github.com/clangen/musikcube/wiki/building#linux-and-bsd) with all `libboost` dependencies bumped to `1.71.0` as opposed to `1.67.0`. Confirmed fixed.

Finally after all this time contributing to FOSS projects by opening issues, I contributed some code!