### PR TITLE
Fix WASAPI to use a higher quality resampler (via `ffmpeg` `IDecoder` plugin)

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,8 @@
 0.96.8
 
+* updated `FfmpegDecoder` to perform resampling internally when `WasapiOutput`
+  is in use; it's internal resampler seems to be much higher quality than the
+  one used by WASAPI by default.
 * ensure TrackSearchLayout refreshes during metadata indexing (@ravensiris)
 * fixed album duration calculation fencepost error (@PythonTryHard)
 * added Spanish (es_ES) translation (@orestescm76)

--- a/src/musikcore/audio/IStream.h
+++ b/src/musikcore/audio/IStream.h
@@ -39,6 +39,7 @@
 #include <musikcore/sdk/IDecoder.h>
 #include <musikcore/sdk/IDSP.h>
 #include <musikcore/sdk/IDecoderFactory.h>
+#include <musikcore/sdk/IOutput.h>
 
 #include <list>
 
@@ -50,7 +51,7 @@ namespace musik { namespace core { namespace audio {
             virtual void OnBufferProcessedByPlayer(musik::core::sdk::IBuffer* buffer) = 0;
             virtual double SetPosition(double seconds) = 0;
             virtual double GetDuration() = 0;
-            virtual bool OpenStream(std::string uri) = 0;
+            virtual bool OpenStream(std::string uri, musik::core::sdk::IOutput* output) = 0;
             virtual void Interrupt() = 0;
             virtual int GetCapabilities() = 0;
             virtual bool Eof() = 0;

--- a/src/musikcore/audio/Outputs.cpp
+++ b/src/musikcore/audio/Outputs.cpp
@@ -63,19 +63,20 @@ static const std::string defaultOutput = "PulseAudio";
 
 class NoOutput: public IOutput {
     public:
-        virtual void Release() { delete this; }
-        virtual void Pause() { }
-        virtual void Resume() { }
-        virtual void SetVolume(double volume) { this->volume = volume; }
-        virtual double GetVolume() { return this->volume; }
-        virtual void Stop() { }
-        virtual OutputState Play(IBuffer *buffer, IBufferProvider *provider) { return OutputState::InvalidState; }
-        virtual void Drain() { }
-        virtual double Latency() { return 0.0; }
-        virtual const char* Name() { return "NoOutput"; }
-        virtual IDeviceList* GetDeviceList() { return nullptr; }
-        virtual bool SetDefaultDevice(const char* deviceId) { return false; }
-        virtual IDevice* GetDefaultDevice() { return nullptr; }
+        void Release() override { delete this; }
+        void Pause() override { }
+        void Resume() override { }
+        void SetVolume(double volume) override { this->volume = volume; }
+        double GetVolume() override { return this->volume; }
+        void Stop() override { }
+        OutputState Play(IBuffer *buffer, IBufferProvider *provider) override { return OutputState::InvalidState; }
+        void Drain() override { }
+        double Latency() override { return 0.0; }
+        const char* Name() override { return "NoOutput"; }
+        IDeviceList* GetDeviceList() override { return nullptr; }
+        bool SetDefaultDevice(const char* deviceId) override { return false; }
+        IDevice* GetDefaultDevice() override { return nullptr; }
+        int GetDefaultSampleRate() override { return -1; }
     private:
         double volume{ 1.0f };
 };

--- a/src/musikcore/audio/Player.cpp
+++ b/src/musikcore/audio/Player.cpp
@@ -296,7 +296,7 @@ void musik::core::audio::playerThreadLoop(Player* player) {
         gain = player->gain.peak;
     }
 
-    if (player->stream->OpenStream(player->url)) {
+    if (player->stream->OpenStream(player->url, player->output.get())) {
         for (Listener* l : player->Listeners()) {
             player->streamState = StreamState::Buffered;
             l->OnPlayerBuffered(player);

--- a/src/musikcore/audio/Stream.h
+++ b/src/musikcore/audio/Stream.h
@@ -39,6 +39,8 @@
 #include <musikcore/audio/Buffer.h>
 #include <musikcore/audio/IStream.h>
 #include <musikcore/sdk/IDecoder.h>
+#include <musikcore/sdk/IOutput.h>
+
 #include <musikcore/sdk/IDSP.h>
 #include <musikcore/sdk/constants.h>
 
@@ -73,15 +75,15 @@ namespace musik { namespace core { namespace audio {
         public:
             virtual ~Stream();
 
-            virtual IBuffer* GetNextProcessedOutputBuffer() override;
-            virtual void OnBufferProcessedByPlayer(IBuffer* buffer) override;
-            virtual double SetPosition(double seconds) override;
-            virtual double GetDuration() override;
-            virtual bool OpenStream(std::string uri) override;
-            virtual void Interrupt() override;
-            virtual int GetCapabilities() override;
-            virtual bool Eof() override { return this->done; }
-            virtual void Release() override { delete this; }
+            IBuffer* GetNextProcessedOutputBuffer() override;
+            void OnBufferProcessedByPlayer(IBuffer* buffer) override;
+            double SetPosition(double seconds) override;
+            double GetDuration() override;
+            bool OpenStream(std::string uri, musik::core::sdk::IOutput* output) override;
+            void Interrupt() override;
+            int GetCapabilities() override;
+            bool Eof() override { return this->done; }
+            void Release() override { delete this; }
 
         private:
             bool GetNextBufferFromDecoder();

--- a/src/musikcore/c_interface_wrappers.cpp
+++ b/src/musikcore/c_interface_wrappers.cpp
@@ -993,7 +993,7 @@ mcsdk_export double mcsdk_audio_stream_get_duration(mcsdk_audio_stream as) {
 }
 
 mcsdk_export bool mcsdk_audio_stream_open_uri(mcsdk_audio_stream as, const char* uri) {
-    return AUDIOSTREAM(as)->OpenStream(uri);
+    return AUDIOSTREAM(as)->OpenStream(uri, nullptr); /* TODO: fixme; should pass output if available */
 }
 
 mcsdk_export void mcsdk_audio_stream_interrupt(mcsdk_audio_stream as) {

--- a/src/musikcore/library/Indexer.cpp
+++ b/src/musikcore/library/Indexer.cpp
@@ -930,7 +930,7 @@ void Indexer::RunAnalyzers() {
                 audio::IStreamPtr stream = audio::Stream::Create(2048, 2.0, StreamFlags::NoDSP);
 
                 if (stream) {
-                    if (stream->OpenStream(track->Uri())) {
+                    if (stream->OpenStream(track->Uri(), nullptr)) {
 
                         /* decode the stream quickly, passing to all analyzers */
 

--- a/src/musikcore/sdk/IDecoder.h
+++ b/src/musikcore/sdk/IDecoder.h
@@ -47,6 +47,7 @@ namespace musik { namespace core { namespace sdk {
             virtual double GetDuration() = 0;
             virtual bool Open(IDataStream *stream) = 0;
             virtual bool Exhausted() = 0;
+            virtual void SetPreferredSampleRate(int rate) = 0;
     };
 
 } } }

--- a/src/musikcore/sdk/IOutput.h
+++ b/src/musikcore/sdk/IOutput.h
@@ -55,6 +55,7 @@ namespace musik { namespace core { namespace sdk {
             virtual void Drain() = 0;
             virtual double Latency() = 0;
             virtual const char* Name() = 0;
+            virtual int GetDefaultSampleRate() = 0;
             virtual IDeviceList* GetDeviceList() = 0;
             virtual bool SetDefaultDevice(const char* deviceId) = 0;
             virtual IDevice* GetDefaultDevice() = 0;

--- a/src/musikcore/sdk/constants.h
+++ b/src/musikcore/sdk/constants.h
@@ -161,5 +161,5 @@ namespace musik {
                 static const char* ExternalId = "external_id";
             }
 
-            static const int SdkVersion = 20;
+            static const int SdkVersion = 21;
 } } }

--- a/src/plugins/alsaout/AlsaOut.h
+++ b/src/plugins/alsaout/AlsaOut.h
@@ -51,25 +51,26 @@ class AlsaOut : public musik::core::sdk::IOutput {
         virtual ~AlsaOut();
 
         /* IPlugin */
-        virtual const char* Name() override { return "AlsaOut"; }
+        const char* Name() override { return "AlsaOut"; }
 
         /* IOutput */
-        virtual void Release() override;
-        virtual void Pause() override ;
-        virtual void Resume() override;
-        virtual void SetVolume(double volume) override;
-        virtual double GetVolume() override;
-        virtual void Stop() override;
-        virtual double Latency() override;
-        virtual void Drain() override;
+        void Release() override;
+        void Pause() override ;
+        void Resume() override;
+        void SetVolume(double volume) override;
+        double GetVolume() override;
+        void Stop() override;
+        double Latency() override;
+        void Drain() override;
 
-        virtual musik::core::sdk::OutputState Play(
+        musik::core::sdk::OutputState Play(
             musik::core::sdk::IBuffer *buffer,
             musik::core::sdk::IBufferProvider *provider) override;
 
-        virtual musik::core::sdk::IDeviceList* GetDeviceList() override;
-        virtual bool SetDefaultDevice(const char* deviceId) override;
-        virtual musik::core::sdk::IDevice* GetDefaultDevice() override;
+        musik::core::sdk::IDeviceList* GetDeviceList() override;
+        bool SetDefaultDevice(const char* deviceId) override;
+        musik::core::sdk::IDevice* GetDefaultDevice() override;
+        int GetDefaultSampleRate() override { return -1; }
 
     private:
         struct BufferContext {

--- a/src/plugins/cddadecoder/CddaDecoder.h
+++ b/src/plugins/cddadecoder/CddaDecoder.h
@@ -50,6 +50,7 @@ class CddaDecoder : public IDecoder {
         double GetDuration() override;
         bool GetBuffer(IBuffer *buffer) override;
         bool Exhausted() noexcept override { return this->exhausted; }
+        void SetPreferredSampleRate(int rate) override { }
 
     private:
         CddaDataStream* data;

--- a/src/plugins/coreaudioout/CoreAudioOut.h
+++ b/src/plugins/coreaudioout/CoreAudioOut.h
@@ -55,25 +55,26 @@ class CoreAudioOut : public musik::core::sdk::IOutput {
         virtual ~CoreAudioOut();
 
         /* IPlugin */
-        virtual const char* Name() override { return "CoreAudio"; }
+        const char* Name() override { return "CoreAudio"; }
 
         /* IOutput */
-        virtual void Release() override;
-        virtual void Pause() override;
-        virtual void Resume() override;
-        virtual void SetVolume(double volume) override;
-        virtual double GetVolume() override;
-        virtual void Stop() override;
-        virtual double Latency() override { return 0.0; }
-        virtual void Drain() override;
+        void Release() override;
+        void Pause() override;
+        void Resume() override;
+        void SetVolume(double volume) override;
+        double GetVolume() override;
+        void Stop() override;
+        double Latency() override { return 0.0; }
+        void Drain() override;
 
-        virtual musik::core::sdk::OutputState Play(
+        musik::core::sdk::OutputState Play(
             musik::core::sdk::IBuffer *buffer,
             musik::core::sdk::IBufferProvider *provider) override;
 
-        virtual musik::core::sdk::IDeviceList* GetDeviceList() override;
-        virtual bool SetDefaultDevice(const char* deviceId) override;
-        virtual musik::core::sdk::IDevice* GetDefaultDevice() override;
+        musik::core::sdk::IDeviceList* GetDeviceList() override;
+        bool SetDefaultDevice(const char* deviceId) override;
+        musik::core::sdk::IDevice* GetDefaultDevice() override;
+        int GetDefaultSampleRate() override { return -1; }
 
         void NotifyBufferCompleted(BufferContext *context);
 

--- a/src/plugins/directsoundout/DirectSoundOut.h
+++ b/src/plugins/directsoundout/DirectSoundOut.h
@@ -57,21 +57,22 @@ class DirectSoundOut : public IOutput {
         ~DirectSoundOut();
 
         /* IPlugin */
-        virtual const char* Name() { return "DirectSound"; };
-        virtual void Release();
+        const char* Name() override { return "DirectSound"; };
+        void Release() override;
 
         /* IOutput */
-        virtual void Pause() override;
-        virtual void Resume() override;
-        virtual void SetVolume(double volume) override;
-        virtual double GetVolume() override;
-        virtual void Stop() override;
-        virtual OutputState Play(IBuffer *buffer, IBufferProvider *provider) override;
-        virtual double Latency() override;
-        virtual void Drain() override;
-        virtual IDeviceList* GetDeviceList() override;
-        virtual bool SetDefaultDevice(const char* deviceId) override;
-        virtual IDevice* GetDefaultDevice() override;
+        void Pause() override;
+        void Resume() override;
+        void SetVolume(double volume) override;
+        double GetVolume() override;
+        void Stop() override;
+        OutputState Play(IBuffer *buffer, IBufferProvider *provider) override;
+        double Latency() override;
+        void Drain() override;
+        IDeviceList* GetDeviceList() override;
+        bool SetDefaultDevice(const char* deviceId) override;
+        IDevice* GetDefaultDevice() override;
+        int GetDefaultSampleRate() override { return -1; }
 
     private:
         enum State {

--- a/src/plugins/ffmpegdecoder/FfmpegDecoder.h
+++ b/src/plugins/ffmpegdecoder/FfmpegDecoder.h
@@ -58,12 +58,13 @@ class FfmpegDecoder: public musik::core::sdk::IDecoder {
         FfmpegDecoder();
         ~FfmpegDecoder();
 
-        virtual void Release() override;
-        virtual double SetPosition(double seconds) override;
-        virtual bool GetBuffer(IBuffer *buffer) override;
-        virtual double GetDuration() override;
-        virtual bool Open(musik::core::sdk::IDataStream *stream) override;
-        virtual bool Exhausted() override;
+        void Release() override;
+        double SetPosition(double seconds) override;
+        bool GetBuffer(IBuffer *buffer) override;
+        double GetDuration() override;
+        bool Open(musik::core::sdk::IDataStream *stream) override;
+        bool Exhausted() override;
+        void SetPreferredSampleRate(int rate) override { }
 
         IDataStream* Stream() { return this->stream; }
 

--- a/src/plugins/ffmpegdecoder/FfmpegDecoder.h
+++ b/src/plugins/ffmpegdecoder/FfmpegDecoder.h
@@ -64,7 +64,7 @@ class FfmpegDecoder: public musik::core::sdk::IDecoder {
         double GetDuration() override;
         bool Open(musik::core::sdk::IDataStream *stream) override;
         bool Exhausted() override;
-        void SetPreferredSampleRate(int rate) override { }
+        void SetPreferredSampleRate(int rate) override { this->preferredSampleRate = rate; }
 
         IDataStream* Stream() { return this->stream; }
 
@@ -87,6 +87,7 @@ class FfmpegDecoder: public musik::core::sdk::IDecoder {
         AVFrame* resampledFrame;
         SwrContext* resampler;
         unsigned char* buffer;
+        int preferredSampleRate { -1 };
         int bufferSize;
         int rate, channels;
         int streamId;

--- a/src/plugins/flacdecoder/FlacDecoder.h
+++ b/src/plugins/flacdecoder/FlacDecoder.h
@@ -47,12 +47,13 @@ class FlacDecoder: public musik::core::sdk::IDecoder {
         FlacDecoder();
         ~FlacDecoder();
 
-        virtual void Release() override;
-        virtual double SetPosition(double seconds) override;
-        virtual bool GetBuffer(IBuffer *buffer) override;
-        virtual double GetDuration() override;
-        virtual bool Open(musik::core::sdk::IDataStream *stream) override;
-        virtual bool Exhausted() override { return this->exhausted; }
+        void Release() override;
+        double SetPosition(double seconds) override;
+        bool GetBuffer(IBuffer *buffer) override;
+        double GetDuration() override;
+        bool Open(musik::core::sdk::IDataStream *stream) override;
+        bool Exhausted() override { return this->exhausted; }
+        void SetPreferredSampleRate(int rate) override { }
 
     private:
         static FLAC__StreamDecoderReadStatus FlacRead(

--- a/src/plugins/gmedecoder/GmeDecoder.h
+++ b/src/plugins/gmedecoder/GmeDecoder.h
@@ -49,12 +49,13 @@ class GmeDecoder: public musik::core::sdk::IDecoder {
         GmeDecoder();
         virtual ~GmeDecoder();
 
-        virtual void Release() override;
-        virtual double SetPosition(double seconds) override;
-        virtual bool GetBuffer(IBuffer *buffer) override;
-        virtual double GetDuration() override;
-        virtual bool Open(musik::core::sdk::IDataStream *stream) override;
-        virtual bool Exhausted() override;
+        void Release() override;
+        double SetPosition(double seconds) override;
+        bool GetBuffer(IBuffer *buffer) override;
+        double GetDuration() override;
+        bool Open(musik::core::sdk::IDataStream *stream) override;
+        bool Exhausted() override;
+        void SetPreferredSampleRate(int rate) override { }
 
     private:
         GmeDataStream* stream { nullptr };

--- a/src/plugins/libopenmptdecoder/OpenMptDecoder.h
+++ b/src/plugins/libopenmptdecoder/OpenMptDecoder.h
@@ -53,6 +53,7 @@ class OpenMptDecoder: public musik::core::sdk::IDecoder {
         double GetDuration() override;
         bool Open(musik::core::sdk::IDataStream* stream) override;
         bool Exhausted() override;
+        void SetPreferredSampleRate(int rate) override { }
 
         musik::core::sdk::IDataStream* Stream() { return this->stream; }
 

--- a/src/plugins/m4adecoder/M4aDecoder.h
+++ b/src/plugins/m4adecoder/M4aDecoder.h
@@ -43,12 +43,13 @@ class M4aDecoder : public musik::core::sdk::IDecoder {
         M4aDecoder();
         ~M4aDecoder();
 
-        virtual void Release() override;
-        virtual double SetPosition(double seconds) override;
-        virtual bool GetBuffer(musik::core::sdk::IBuffer *buffer) override;
-        virtual double GetDuration() override;
-        virtual bool Open(musik::core::sdk::IDataStream *stream) override;
-        virtual bool Exhausted() override { return this->exhausted; }
+        void Release() override;
+        double SetPosition(double seconds) override;
+        bool GetBuffer(musik::core::sdk::IBuffer *buffer) override;
+        double GetDuration() override;
+        bool Open(musik::core::sdk::IDataStream *stream) override;
+        bool Exhausted() override { return this->exhausted; }
+        void SetPreferredSampleRate(int rate) override { }
 
     private:
         NeAACDecHandle decoder;

--- a/src/plugins/mpg123decoder/Mpg123Decoder.h
+++ b/src/plugins/mpg123decoder/Mpg123Decoder.h
@@ -44,11 +44,12 @@ class Mpg123Decoder : public musik::core::sdk::IDecoder {
         Mpg123Decoder();
         virtual ~Mpg123Decoder();
 
-        virtual bool Open(musik::core::sdk::IDataStream *dataStream);
-        virtual double SetPosition(double seconds);
-        virtual bool GetBuffer(musik::core::sdk::IBuffer *buffer);
-        virtual void Destroy();
-        virtual double GetDuration();
+        bool Open(musik::core::sdk::IDataStream *dataStream) override;
+        double SetPosition(double seconds) override;
+        bool GetBuffer(musik::core::sdk::IBuffer *buffer) override;
+        void Destroy() override;
+        double GetDuration() override;
+        void SetPreferredSampleRate(int rate) override { }
 
     private:
         bool Feed();

--- a/src/plugins/nomaddecoder/NomadDecoder.h
+++ b/src/plugins/nomaddecoder/NomadDecoder.h
@@ -46,12 +46,13 @@ class NomadDecoder : public musik::core::sdk::IDecoder {
         NomadDecoder();
         ~NomadDecoder();
 
-        virtual bool Open(musik::core::sdk::IDataStream *dataStream) override;
-        virtual double SetPosition(double seconds) override;
-        virtual bool GetBuffer(musik::core::sdk::IBuffer *buffer) override;
-        virtual double GetDuration() override;
-        virtual void Release() override;
-        virtual bool Exhausted() override { return this->exhausted; }
+        bool Open(musik::core::sdk::IDataStream *dataStream) override;
+        double SetPosition(double seconds) override;
+        bool GetBuffer(musik::core::sdk::IBuffer *buffer) override;
+        double GetDuration() override;
+        void Release() override;
+        bool Exhausted() override { return this->exhausted; }
+        void SetPreferredSampleRate(int rate) override { }
 
     private:
         size_t GetId3v2HeaderLength(musik::core::sdk::IDataStream *stream);

--- a/src/plugins/nullout/NullOut.h
+++ b/src/plugins/nullout/NullOut.h
@@ -61,6 +61,7 @@ class NullOut : public IOutput {
         IDeviceList* GetDeviceList() override;
         bool SetDefaultDevice(const char* deviceId) override;
         IDevice* GetDefaultDevice() override;
+        int GetDefaultSampleRate() override { return -1; }
 
     private:
         enum State {

--- a/src/plugins/oggdecoder/OggDecoder.h
+++ b/src/plugins/oggdecoder/OggDecoder.h
@@ -45,12 +45,13 @@ class OggDecoder : public IDecoder {
         OggDecoder();
         ~OggDecoder();
 
-        virtual void Release() override;
-        virtual double SetPosition(double second) override;
-        virtual bool GetBuffer(IBuffer *buffer) override;
-        virtual double GetDuration() override;
-        virtual bool Open(musik::core::sdk::IDataStream *fileStream) override;
-        virtual bool Exhausted() override { return this->exhausted; }
+        void Release() override;
+        double SetPosition(double second) override;
+        bool GetBuffer(IBuffer *buffer) override;
+        double GetDuration() override;
+        bool Open(musik::core::sdk::IDataStream *fileStream) override;
+        bool Exhausted() override { return this->exhausted; }
+        void SetPreferredSampleRate(int rate) override { }
 
         /* libvorbis callbacks */
         static size_t OggRead(void *buffer, size_t nofParts, size_t partSize, void *datasource);

--- a/src/plugins/pipewireout/PipeWireOut.h
+++ b/src/plugins/pipewireout/PipeWireOut.h
@@ -66,6 +66,7 @@ class PipeWireOut : public IOutput {
         IDeviceList* GetDeviceList() override;
         bool SetDefaultDevice(const char* deviceId) override;
         IDevice* GetDefaultDevice() override;
+        int GetDefaultSampleRate() override { return -1; }
 
     private:
         bool StartPipeWire(IBuffer* buffer);

--- a/src/plugins/pulseout/PulseOut.h
+++ b/src/plugins/pulseout/PulseOut.h
@@ -47,25 +47,26 @@ class PulseOut : public musik::core::sdk::IOutput {
         virtual ~PulseOut();
 
         /* IPlugin */
-        virtual const char* Name() override { return "PulseAudio"; }
+        const char* Name() override { return "PulseAudio"; }
 
         /* IOutput */
-        virtual void Release() override;
-        virtual void Pause() override;
-        virtual void Resume() override;
-        virtual void SetVolume(double volume) override;
-        virtual double GetVolume() override;
-        virtual void Stop() override;
-        virtual double Latency() override;
-        virtual void Drain() override;
+        void Release() override;
+        void Pause() override;
+        void Resume() override;
+        void SetVolume(double volume) override;
+        double GetVolume() override;
+        void Stop() override;
+        double Latency() override;
+        void Drain() override;
 
-        virtual musik::core::sdk::OutputState Play(
+        musik::core::sdk::OutputState Play(
             musik::core::sdk::IBuffer *buffer,
             musik::core::sdk::IBufferProvider *provider) override;
 
-        virtual musik::core::sdk::IDeviceList* GetDeviceList() override;
-        virtual bool SetDefaultDevice(const char* deviceId) override;
-        virtual musik::core::sdk::IDevice* GetDefaultDevice() override;
+        musik::core::sdk::IDeviceList* GetDeviceList() override;
+        bool SetDefaultDevice(const char* deviceId) override;
+        musik::core::sdk::IDevice* GetDefaultDevice() override;
+        int GetDefaultSampleRate() override { return -1; }
 
     private:
         enum State {

--- a/src/plugins/sndioout/SndioOut.h
+++ b/src/plugins/sndioout/SndioOut.h
@@ -50,21 +50,22 @@ class SndioOut : public IOutput {
         ~SndioOut();
 
         /* IPlugin */
-        virtual const char* Name() override { return "sndio"; };
-        virtual void Release() override;
+        const char* Name() override { return "sndio"; };
+        void Release() override;
 
         /* IOutput */
-        virtual void Pause() override;
-        virtual void Resume() override;
-        virtual void SetVolume(double volume) override;
-        virtual double GetVolume() override;
-        virtual void Stop() override;
-        virtual musik::core::sdk::OutputState Play(IBuffer *buffer, IBufferProvider *provider) override;
-        virtual double Latency() override;
-        virtual void Drain() override;
-        virtual IDeviceList* GetDeviceList() override;
-        virtual bool SetDefaultDevice(const char* deviceId) override;
-        virtual IDevice* GetDefaultDevice() override;
+        void Pause() override;
+        void Resume() override;
+        void SetVolume(double volume) override;
+        double GetVolume() override;
+        void Stop() override;
+        musik::core::sdk::OutputState Play(IBuffer *buffer, IBufferProvider *provider) override;
+        double Latency() override;
+        void Drain() override;
+        IDeviceList* GetDeviceList() override;
+        bool SetDefaultDevice(const char* deviceId) override;
+        IDevice* GetDefaultDevice() override;
+        int GetDefaultSampleRate() override { return -1; }
 
     private:
         enum class Command: int {

--- a/src/plugins/wasapiout/WasapiOut.h
+++ b/src/plugins/wasapiout/WasapiOut.h
@@ -55,21 +55,21 @@ class WasapiOut : public IOutput {
         ~WasapiOut();
 
         /* IPlugin */
-        virtual const char* Name() { return "WASAPI"; };
-        virtual void Release();
+        const char* Name() override { return "WASAPI"; };
+        void Release() override;
 
         /* IOutput */
-        virtual void Pause() override;
-        virtual void Resume() override;
-        virtual void SetVolume(double volume) override;
-        virtual double GetVolume() override;
-        virtual void Stop() override;
-        virtual OutputState Play(IBuffer *buffer, IBufferProvider *provider) override;
-        virtual double Latency() override;
-        virtual void Drain() override;
-        virtual IDeviceList* GetDeviceList() override;
-        virtual bool SetDefaultDevice(const char* deviceId) override;
-        virtual IDevice* GetDefaultDevice() override;
+        void Pause() override;
+        void Resume() override;
+        void SetVolume(double volume) override;
+        double GetVolume() override;
+        void Stop() override;
+        OutputState Play(IBuffer *buffer, IBufferProvider *provider) override;
+        double Latency() override;
+        void Drain() override;
+        IDeviceList* GetDeviceList() override;
+        bool SetDefaultDevice(const char* deviceId) override;
+        IDevice* GetDefaultDevice() override;
 
         void OnDeviceChanged() { this->deviceChanged = true; }
 

--- a/src/plugins/wasapiout/WasapiOut.h
+++ b/src/plugins/wasapiout/WasapiOut.h
@@ -70,6 +70,7 @@ class WasapiOut : public IOutput {
         IDeviceList* GetDeviceList() override;
         bool SetDefaultDevice(const char* deviceId) override;
         IDevice* GetDefaultDevice() override;
+        int GetDefaultSampleRate() override;
 
         void OnDeviceChanged() { this->deviceChanged = true; }
 
@@ -81,6 +82,7 @@ class WasapiOut : public IOutput {
         };
 
         bool Configure(IBuffer *buffer);
+        bool InitializeAudioClient();
         void Reset();
         IMMDevice* GetPreferredDevice();
 

--- a/src/plugins/waveout/WaveOut.h
+++ b/src/plugins/waveout/WaveOut.h
@@ -51,21 +51,22 @@ class WaveOut : public IOutput {
         ~WaveOut();
 
         /* IPlugin */
-        virtual const char* Name() { return "WaveOut"; };
-        virtual void Release();
+        const char* Name() override { return "WaveOut"; };
+        void Release() override;
 
         /* IOutput */
-        virtual void Pause() override;
-        virtual void Resume() override;
-        virtual void SetVolume(double volume) override;
-        virtual double GetVolume() override;
-        virtual void Stop() override;
-        virtual OutputState Play(IBuffer *buffer, IBufferProvider *provider) override;
-        virtual double Latency() override { return 0.0; }
-        virtual void Drain() override { }
-        virtual IDeviceList* GetDeviceList() override;
-        virtual bool SetDefaultDevice(const char* deviceId) override;
-        virtual IDevice* GetDefaultDevice() override;
+        void Pause() override;
+        void Resume() override;
+        void SetVolume(double volume) override;
+        double GetVolume() override;
+        void Stop() override;
+        OutputState Play(IBuffer *buffer, IBufferProvider *provider) override;
+        double Latency() override { return 0.0; }
+        void Drain() override { }
+        IDeviceList* GetDeviceList() override;
+        bool SetDefaultDevice(const char* deviceId) override;
+        IDevice* GetDefaultDevice() override;
+        int GetDefaultSampleRate() override { return -1; }
 
         void OnBufferWrittenToOutput(WaveOutBuffer *buffer);
 


### PR DESCRIPTION
* Updated `IOutput`, `IStream` and `IDecoder` interfaces to allow for querying and setting default/preferred output sample rates. Nothing is wired up yet.
* Updated `WasapiOutput` to query the default sample rate supported by the selected output device
* Updated `Stream` to query the default sample rate from the specified `IOutput` device, and send it to the selected `IDecoder`
* Updated `FfmpegDecoder` to use any preferred output sample rate specified; if none (or invalid), use whatever sample rate is defined in the current input stream.