### PR TITLE
Fix data directory when using XDG

### DIFF
--- a/src/musikcore/support/Common.cpp
+++ b/src/musikcore/support/Common.cpp
@@ -81,14 +81,6 @@ static inline void silentDelete(const std::string fn) {
 
 namespace musik { namespace core {
 
-    static std::string getDataDirectoryRoot() {
-    #ifdef WIN32
-        return GetHomeDirectory();
-    #else
-        return GetHomeDirectory() + "/.config";
-    #endif
-    }
-
     std::string GetPluginDirectory() {
         std::string path(GetApplicationDirectory());
         path.append("/plugins/");
@@ -166,7 +158,7 @@ namespace musik { namespace core {
             directory = std::string(result);
         }
         else {
-            directory = std::string(std::getenv("HOME"));
+            directory = std::string(std::getenv("HOME")) + std::string("/.config/");
         }
     #endif
 
@@ -174,7 +166,7 @@ namespace musik { namespace core {
     }
 
     std::string GetDataDirectory(bool create) {
-        std::string directory = getDataDirectoryRoot() + std::string("/musikcube/");
+        std::string directory = GetHomeDirectory() + std::string("/musikcube/");
 
         if (create) {
             try {


### PR DESCRIPTION
Since https://github.com/clangen/musikcube/commit/7fbed0513588f57e0a9f42e7363f122f643bd842
musikcube detects `$XDG_CONFIG_HOME` with `GetHomeDirectory`.
There is an intermediate call to `getDataDirectoryRoot` though which
appends `/.config`, stemming from when `GetHomeDirectory` would actually
return `$HOME`. This leads to the situation where on most systems where
config home is already under `$HOME/.config/` musikcube will create
`$HOME/.config/.config/musikcube` for itself.

We fix this by removing the `getDataDirectoryRoot` shim entirely.

Signed-off-by: Robert Günzler <r@gnzler.io>