### PR TITLE
always use "%s"-style format for printf()-style functions

### DIFF
--- a/src/musikcube/app/window/TransportWindow.cpp
+++ b/src/musikcube/app/window/TransportWindow.cpp
@@ -331,7 +331,7 @@ static size_t writePlayingFormat(
         }
 
         ON(w, attr);
-        checked_wprintw(w, value.c_str());
+        checked_wprintw(w, "%s", value.c_str());
         OFF(w, attr);
 
         remaining -= cols;
@@ -623,7 +623,7 @@ void TransportWindow::Update(TimeMode timeMode) {
 
     if (stopped && !this->buffering) {
         ON(c, disabled);
-        checked_wprintw(c, Strings.STOPPED.c_str());
+        checked_wprintw(c, "%s", Strings.STOPPED.c_str());
         displayCache->Reset();
         OFF(c, disabled);
     }
@@ -637,7 +637,7 @@ void TransportWindow::Update(TimeMode timeMode) {
     wmove(c, 0, shuffleOffset);
     Color const shuffleAttrs = this->playback.IsShuffled() ? gb : disabled;
     ON(c, shuffleAttrs);
-    checked_wprintw(c, shuffleLabel.c_str());
+    checked_wprintw(c, "%s", shuffleLabel.c_str());
     OFF(c, shuffleAttrs);
     this->shufflePos.Set(shuffleOffset, (int) shuffleWidth);
 
@@ -756,7 +756,7 @@ void TransportWindow::Update(TimeMode timeMode) {
     wmove(c, 1, 0); /* move cursor to the second line */
 
     ON(c, volumeAttrs);
-    checked_wprintw(c, volume.c_str());
+    checked_wprintw(c, "%s", volume.c_str());
     OFF(c, volumeAttrs);
 
     if (replayGainEnabled) {
@@ -778,7 +778,7 @@ void TransportWindow::Update(TimeMode timeMode) {
 
     ON(c, repeatAttrs);
     this->repeatPos.Set(getcurx(c), (int) u8cols(repeatModeLabel));
-    checked_wprintw(c, repeatModeLabel.c_str());
+    checked_wprintw(c, "%s", repeatModeLabel.c_str());
     OFF(c, repeatAttrs);
 
     this->Invalidate();

--- a/src/musikcube/cursespp/DialogOverlay.cpp
+++ b/src/musikcube/cursespp/DialogOverlay.cpp
@@ -226,7 +226,7 @@ void DialogOverlay::Redraw() {
     if (this->title.size()) {
         wmove(c, currentY, currentX);
         wattron(c, A_BOLD);
-        checked_wprintw(c, text::Ellipsize(this->title, this->width - 4).c_str());
+        checked_wprintw(c, "%s", text::Ellipsize(this->title, this->width - 4).c_str());
         wattroff(c, A_BOLD);
         currentY += 2;
     }
@@ -234,7 +234,7 @@ void DialogOverlay::Redraw() {
     if (this->message.size()) {
         for (size_t i = 0; i < messageLines.size(); i++) {
             wmove(c, currentY, currentX);
-            checked_wprintw(c, this->messageLines.at(i).c_str());
+            checked_wprintw(c, "%s", this->messageLines.at(i).c_str());
             ++currentY;
         }
     }

--- a/src/musikcube/cursespp/InputOverlay.cpp
+++ b/src/musikcube/cursespp/InputOverlay.cpp
@@ -203,7 +203,7 @@ void InputOverlay::Redraw() {
     if (this->title.size()) {
         wmove(c, 0, 1);
         wattron(c, A_BOLD);
-        checked_wprintw(c, text::Align(this->title, text::AlignCenter, this->width - 4).c_str());
+        checked_wprintw(c, "%s", text::Align(this->title, text::AlignCenter, this->width - 4).c_str());
         wattroff(c, A_BOLD);
     }
 }

--- a/src/musikcube/cursespp/ListOverlay.cpp
+++ b/src/musikcube/cursespp/ListOverlay.cpp
@@ -328,7 +328,7 @@ void ListOverlay::UpdateContents() {
     if (this->title.size()) {
         wmove(c, currentY, currentX);
         wattron(c, A_BOLD);
-        checked_wprintw(c, text::Align(this->title, text::AlignCenter, this->width - 4).c_str());
+        checked_wprintw(c, "%s", text::Align(this->title, text::AlignCenter, this->width - 4).c_str());
         wattroff(c, A_BOLD);
         currentY += 2;
     }

--- a/src/musikcube/cursespp/ShortcutsWindow.cpp
+++ b/src/musikcube/cursespp/ShortcutsWindow.cpp
@@ -236,7 +236,7 @@ void ShortcutsWindow::OnRedraw() {
         }
 
         wattron(c, keyAttrs);
-        checked_wprintw(c, key.c_str());
+        checked_wprintw(c, "%s", key.c_str());
         wattroff(c, keyAttrs);
 
         remaining -= len;
@@ -252,7 +252,7 @@ void ShortcutsWindow::OnRedraw() {
             len = remaining;
         }
 
-        checked_wprintw(c, value.c_str());
+        checked_wprintw(c, "%s", value.c_str());
         remaining -= len;
     }
 }

--- a/src/musikcube/cursespp/ToastOverlay.cpp
+++ b/src/musikcube/cursespp/ToastOverlay.cpp
@@ -115,6 +115,6 @@ void ToastOverlay::OnRedraw() {
 
      for (int i = 0; i < (int) this->titleLines.size(); i++) {
          wmove(c, i, 1);
-         checked_wprintw(c, text::Ellipsize(this->titleLines[i], this->width - 4).c_str());
+         checked_wprintw(c, "%s", text::Ellipsize(this->titleLines[i], this->width - 4).c_str());
      }
 }


### PR DESCRIPTION
`ncuses-6.3` added printf-style function attributes and now makes
it easier to catch cases when user input is used in palce of format
string when built with CFLAGS=-Werror=format-security:

    musikcube/cursespp/cursespp/curses_config.h:54:36:
     error: format not a string literal and no format arguments [-Werror=format-security]
       54 |     if (window && format) { wprintw(window, format, ##__VA_ARGS__); }
          |                             ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    musikcube/src/musikcube/app/window/TransportWindow.cpp:640:5: note: in expansion of macro 'checked_wprintw'
      640 |     checked_wprintw(c, shuffleLabel.c_str(

Let's wrap all the missing places with "%s" format.