### PR TITLE
Fix width of time tracker when muted

### DIFF
--- a/src/musikcube/app/window/TransportWindow.cpp
+++ b/src/musikcube/app/window/TransportWindow.cpp
@@ -774,8 +774,9 @@ void TransportWindow::Update(TimeMode timeMode) {
 
     const std::string replayGain = replayGainEnabled  ? "rg" : "";
 
+    int const escapedPercentSignWidth = (muted ? 0 : 1); /* 1 for escaped percent sign when not muted */
     int const bottomRowControlsWidth =
-        displayCache.Columns(volume) - (muted ? 0 : 1) + /* -1 for escaped percent sign when not muted */
+        displayCache.Columns(volume) - escapedPercentSignWidth +
         (replayGainEnabled ? (narrow_cast<int>(u8cols(replayGain)) + 4) : 0) +  /* [] brackets */
         narrow_cast<int>(u8cols(currentTime)) + 1 + /* +1 for space padding */
         /* timer track with thumb */
@@ -784,7 +785,8 @@ void TransportWindow::Update(TimeMode timeMode) {
 
     int const timerTrackWidth =
         this->GetContentWidth() -
-        bottomRowControlsWidth - 1; /* this  `- 1` is a hack i don't know why we need it please send help */
+        bottomRowControlsWidth -
+        escapedPercentSignWidth;
 
     thumbOffset = 0;
 


### PR DESCRIPTION
This PR accounts for the escaped percent sign when muted during calculation of the width for the time tracker in the bottom bar.

When `musikcube` is muted the time tracker in the bottom bar width is miscalculated by one character and the repeat indicator is inset by one character to the left, see examples below:

**Before**
```
 playback is stopped                             shuffle
 vol ──■──────── 20%  0:00 ■─────────── 0:00  repeat off  # ← Notice how `off` aligns nicely with `shuffle` above
 
 playback is stopped                             shuffle
 muted  0:00 ■──────────────────────── 0:00  repeat off   # ← Notice how the last `f` in `off` no longer aligns with the `e` from `shuffle` above
```

**After**
```
 playback is stopped                             shuffle
 vol ──■──────── 20%  0:00 ■─────────── 0:00  repeat off
 
 playback is stopped                             shuffle
 muted  0:00 ■───────────────────────── 0:00  repeat off  # ← Notice how `off` stays aligned with `shuffle` above

```