### PR TITLE
Use itemMap() in taglib metadata reader

### DIFF
--- a/src/plugins/taglib_plugin/TaglibMetadataReader.cpp
+++ b/src/plugins/taglib_plugin/TaglibMetadataReader.cpp
@@ -320,7 +320,7 @@ bool TaglibMetadataReader::ReadGeneric(
             if (!handled) {
                 const auto mp4File = dynamic_cast<TagLib::MP4::File*>(file.file());
                 if (mp4File && mp4File->hasMP4Tag()) {
-                    auto mp4TagMap = static_cast<TagLib::MP4::Tag*>(tag)->itemListMap();
+                    auto mp4TagMap = static_cast<TagLib::MP4::Tag*>(tag)->itemMap();
                     this->ExtractValueForKey(mp4TagMap, "aART", "album_artist", target);
                     this->ExtractValueForKey(mp4TagMap, "disk", "disc", target);
                     this->ExtractReplayGain(mp4TagMap, target);


### PR DESCRIPTION
With the recent release of TagLib 2.0, the use of MP4::Tag::itemListMap() has been dropped in favor of itemMap(), which appears to be supported in previous releases of TagLib.