### PR TITLE
Fix build on DragonFly BSD

### DIFF
--- a/.cmake/ConfigureCurses.cmake
+++ b/.cmake/ConfigureCurses.cmake
@@ -4,6 +4,7 @@ if(
     EXISTS "/etc/manjaro-release" OR
     CMAKE_SYSTEM_NAME MATCHES "FreeBSD" OR
     CMAKE_SYSTEM_NAME MATCHES "OpenBSD" OR
+    CMAKE_SYSTEM_NAME MATCHES "DragonFly" OR
     CMAKE_SYSTEM_NAME MATCHES "Haiku"
 )
   add_definitions (-DNO_NCURSESW)

--- a/src/musikcore/support/Common.cpp
+++ b/src/musikcore/support/Common.cpp
@@ -77,6 +77,11 @@
     #include <sys/sysctl.h>
 #endif
 
+#ifdef __DragonFly__
+    #include <sys/types.h>
+    #include <sys/sysctl.h>
+#endif
+
 namespace fs = std::filesystem;
 
 static inline void silentDelete(const std::string fn) {

--- a/src/musikcube/CMakeLists.txt
+++ b/src/musikcube/CMakeLists.txt
@@ -92,7 +92,7 @@ if (NOT DEFINED ENABLE_MACOS_SYSTEM_NCURSES)
 endif()
 
 # figure out if we have a "w" suffix or not...
-if ((${DISABLE_WIDE_NCURSES_LIB_SUFFIXES} MATCHES "true") OR ((APPLE) AND (${ENABLE_MACOS_SYSTEM_NCURSES} MATCHES "true")))
+if ((${DISABLE_WIDE_NCURSES_LIB_SUFFIXES} MATCHES "true") OR ((APPLE) AND (${ENABLE_MACOS_SYSTEM_NCURSES} MATCHES "true")) OR (CMAKE_SYSTEM_NAME MATCHES "DragonFly"))
     message(STATUS "[ncurses] using library names *WITHOUT* 'w' prefix")
     set(CURSES_LIBRARY_NAME ncurses)
     set(PANEL_LIBRARY_NAME panel)

--- a/src/musikcube/cursespp/cursespp/curses_config.h
+++ b/src/musikcube/cursespp/cursespp/curses_config.h
@@ -40,9 +40,12 @@
 #undef MOUSE_MOVED
 #endif
 
-#if defined(WIN32) || defined(NO_NCURSESW)
+#if defined(WIN32) || defined(NO_NCURSESW) && !defined(__DragonFly__)
     #include <curses.h>
     #include <panel.h>
+#elif defined(__DragonFly__)
+    #include <ncurses/curses.h>
+    #include <ncurses/panel.h>
 #else
     #include <ncursesw/curses.h>
     #include <ncursesw/panel.h>


### PR DESCRIPTION
Need use gcc > 8 for building:

sudo pkg install gcc-12_5
export CC=/usr/local/bin/gcc; export CXX=/usr/local/bin/g++ cmake -G "Unix Makefiles" .
make