### PR TITLE
mpris: reduce command latency in event loop

### DIFF
--- a/src/plugins/mpris/mpris.cpp
+++ b/src/plugins/mpris/mpris.cpp
@@ -147,13 +147,16 @@ void MPRISRemote::MPRISLoop() {
             if (stop_processing || !bus) {
                 return;
             }
-            if (sd_bus_process(bus, nullptr) == 0) {
-                if (sd_bus_wait(bus, 0) < 0) {
-                    break;
-                }
+
+            while (sd_bus_process(bus, nullptr) > 0) {
+            }
+
+            if (sd_bus_wait(bus, 0) < 0) {
+                break;
             }
         }
-        usleep(500 * 1000);
+
+        usleep(1000);
     }
 }
 


### PR DESCRIPTION
## Summary
- Remove the fixed 500ms sleep from \`MPRISRemote::MPRISLoop()\` in \`src/plugins/mpris/mpris.cpp\`.
- Drain pending DBus messages each loop iteration before waiting.
- Reduce control latency for MPRIS actions (e.g. \`PlayPause\`) from noticeable delay to near-instant in local testing.

## Context
This targets reported lag when controlling musikcube over MPRIS/playerctl (see issue #551).

## Testing
- Built locally with MPRIS plugin enabled.
- Reproduced latency before patch and verified significantly improved response after patch using \`playerctl\` and \`busctl\`.

### Baseline validation (control path overhead)

**Command:**
`bash -lc 'set -x; date +%s.%3N; time qs -c noctalia-shell ipc call media playPause; date +%s.%3N; playerctl -l; playerctl -p musikcube.instance791874 status'`

**Observed:**
- `qs ... playPause`: real 0m0.020s (~20ms)
- Confirms lag is not in keybind/shell/IPC wrapper.

### Before patch (system musikcube build)

**Command:**
`bash -lc 'for i in {1..8}; do echo "---- $i ----"; time playerctl -p musikcube.instance791874 play-pause; time playerctl -p musikcube.instance791874 status >/dev/null; done'`

**Observed:**
- `playerctl ... play-pause`: typically ~2.5s (e.g. 2.500s, 2.560s, 2.603s)
- `playerctl ... status`: consistently ~0.5s (e.g. 0.500s, 0.509s, 0.551s)

### Direct DBus reproduction (no playerctl wrapper)

`bash -lc 'for i in {1..5}; do echo "== $i =="; time busctl --user call org.mpris.MediaPlayer2.musikcube.instance791874 /org/mpris/MediaPlayer2 org.mpris.MediaPlayer2.Player PlayPause; time busctl --user get-property org.mpris.MediaPlayer2.musikcube.instance791874 /org/mpris/MediaPlayer2 org.mpris.MediaPlayer2.Player PlaybackStatus >/dev/null; done'`

**Observed:**
- `PlayPause`: 0.399s, 2.098s, 1.500s, 2.099s, 2.000s
- `PlaybackStatus`: mostly 0.500s (one 1.000s)
- Confirms lag originates in MPRIS handling, not playerctl.

### After patch (local build)
- Built patched source successfully.
- Manual verification: play/pause control responsiveness became effectively immediate; prior multi-second delay no longer reproduced in normal use.
- UI responsiveness was preserved after adjusting the loop to avoid blocking while holding the mutex.