### PR TITLE
bugfix: fixing wma files not playing after ffmpeg7 upgrade

### DIFF
--- a/src/plugins/ffmpegdecoder/FfmpegDecoder.cpp
+++ b/src/plugins/ffmpegdecoder/FfmpegDecoder.cpp
@@ -344,6 +344,49 @@ bool FfmpegDecoder::InitializeResampler() {
     return true;
 }
 
+void FfmpegDecoder::GuessInputFormat(musik::core::sdk::IDataStream *stream) {
+
+    for (size_t m = 1; m <= 4; m++) {
+        size_t probe_size = PROBE_SIZE * m;
+
+        unsigned char* probe = new unsigned char[probe_size];
+        memset(probe, 0, probe_size);
+        int count = stream->Read(probe, probe_size - AVPROBE_PADDING_SIZE);
+        stream->SetPosition(0);
+
+        AVProbeData probeData = { 0 };
+        probeData.buf = probe;
+        probeData.buf_size = count;
+        probeData.filename = "";
+
+        int score = 0;
+
+        this->formatContext->iformat = av_probe_input_format3(&probeData, 1, &score);
+
+        std::string guessAttemptText =
+            std::string("av_probe_input_format3 attempt ") +
+            std::to_string(m)
+            + std::string(" resulted in ")
+            + std::string(this->formatContext->iformat ? this->formatContext->iformat->name : "nothing")
+            + std::string(" with a score of ")
+            + std::to_string(score);
+
+        delete[] probe;
+
+        ::debug->Info(TAG, guessAttemptText.c_str());
+
+        if (score >= AVPROBE_SCORE_MAX / 4) {
+            return;
+        }
+    }
+
+        std::string bailText =
+            std::string("couldn't reliably guess input format, using last detected: ")
+            + std::string(this->formatContext->iformat ? this->formatContext->iformat->name : "nothing");
+
+    ::debug->Warning(TAG, bailText.c_str());
+}
+
 bool FfmpegDecoder::Open(musik::core::sdk::IDataStream *stream) {
     if (stream->Seekable() && this->ioContext == nullptr) {
         ::debug->Info(TAG, "parsing data stream...");
@@ -368,17 +411,7 @@ bool FfmpegDecoder::Open(musik::core::sdk::IDataStream *stream) {
             this->formatContext->pb = this->ioContext;
             this->formatContext->flags = AVFMT_FLAG_CUSTOM_IO;
 
-            unsigned char probe[PROBE_SIZE];
-            memset(probe, 0, PROBE_SIZE);
-            int count = stream->Read(probe, PROBE_SIZE - AVPROBE_PADDING_SIZE);
-            stream->SetPosition(0);
-
-            AVProbeData probeData = { 0 };
-            probeData.buf = probe;
-            probeData.buf_size = count;
-            probeData.filename = "";
-
-            this->formatContext->iformat = av_probe_input_format(&probeData, 1);
+            this->GuessInputFormat(stream);
 
             if (this->formatContext->iformat) {
                 if (avformat_open_input(&this->formatContext, "", nullptr, nullptr) == 0) {

--- a/src/plugins/ffmpegdecoder/FfmpegDecoder.cpp
+++ b/src/plugins/ffmpegdecoder/FfmpegDecoder.cpp
@@ -89,12 +89,14 @@ static void logError(const std::string& message) {
 }
 
 #ifdef USE_FFMPEG7_CHANNEL_LAYOUT
-static AVChannelLayout resolveChannelLayout(size_t channelCount) {
+static AVChannelLayout resolveChannelLayout(const AVChannelLayout& currentLayout) {
     AVChannelLayout result;
     memset(&result, 0, sizeof(result));
 
-    result.nb_channels = channelCount;
-    switch (channelCount) {
+    result.nb_channels = currentLayout.nb_channels;
+    result.order = currentLayout.order == AV_CHANNEL_ORDER_UNSPEC ? AV_CHANNEL_ORDER_NATIVE : currentLayout.order;
+
+    switch (result.nb_channels) {
         case 1: result.u.mask = AV_CH_LAYOUT_MONO; break;
         case 2: result.u.mask =  AV_CH_LAYOUT_STEREO; break;
         case 3: result.u.mask =  AV_CH_LAYOUT_2POINT1; break;
@@ -105,6 +107,10 @@ static AVChannelLayout resolveChannelLayout(size_t channelCount) {
     }
 
     return result;
+}
+
+static bool requiresChannelLayoutResolve(const AVChannelLayout& currentLayout) {
+    return currentLayout.nb_channels == 0 || currentLayout.order == AV_CHANNEL_ORDER_UNSPEC;
 }
 #endif
 
@@ -418,9 +424,9 @@ bool FfmpegDecoder::Open(musik::core::sdk::IDataStream *stream) {
                             }
 
 #ifdef USE_FFMPEG7_CHANNEL_LAYOUT
-                            if (this->codecContext->ch_layout.nb_channels == 0) {
+                            if (requiresChannelLayoutResolve(this->codecContext->ch_layout)) {
                                 this->codecContext->ch_layout =
-                                    resolveChannelLayout(this->codecContext->ch_layout.nb_channels);
+                                    resolveChannelLayout(this->codecContext->ch_layout);
 #else
                             if (this->codecContext->channel_layout == 0) {
                                 this->codecContext->channel_layout =
@@ -655,8 +661,8 @@ AVFrame* FfmpegDecoder::AllocFrame(AVFrame* original, AVSampleFormat format, int
             av_frame_free(&original);
         }
 #ifdef USE_FFMPEG7_CHANNEL_LAYOUT
-        const AVChannelLayout channelLayout = this->codecContext->ch_layout.nb_channels == 0
-            ? resolveChannelLayout(this->codecContext->ch_layout.nb_channels)
+        const AVChannelLayout channelLayout = requiresChannelLayoutResolve(this->codecContext->ch_layout)
+            ? resolveChannelLayout(this->codecContext->ch_layout)
             : this->codecContext->ch_layout;
         original = av_frame_alloc();
         original->ch_layout = channelLayout;

--- a/src/plugins/ffmpegdecoder/FfmpegDecoder.cpp
+++ b/src/plugins/ffmpegdecoder/FfmpegDecoder.cpp
@@ -345,6 +345,8 @@ bool FfmpegDecoder::InitializeResampler() {
 }
 
 void FfmpegDecoder::GuessInputFormat(musik::core::sdk::IDataStream *stream) {
+    this->formatContext->iformat = NULL;
+    int best_score = 0;
 
     for (size_t m = 1; m <= 4; m++) {
         size_t probe_size = PROBE_SIZE * m;
@@ -361,13 +363,13 @@ void FfmpegDecoder::GuessInputFormat(musik::core::sdk::IDataStream *stream) {
 
         int score = 0;
 
-        this->formatContext->iformat = av_probe_input_format3(&probeData, 1, &score);
+        auto iformat = av_probe_input_format3(&probeData, 1, &score);
 
         std::string guessAttemptText =
             std::string("av_probe_input_format3 attempt ") +
             std::to_string(m)
             + std::string(" resulted in ")
-            + std::string(this->formatContext->iformat ? this->formatContext->iformat->name : "nothing")
+            + std::string(iformat ? iformat->name : "nothing")
             + std::string(" with a score of ")
             + std::to_string(score);
 
@@ -375,13 +377,18 @@ void FfmpegDecoder::GuessInputFormat(musik::core::sdk::IDataStream *stream) {
 
         ::debug->Info(TAG, guessAttemptText.c_str());
 
+        if (this->formatContext->iformat == NULL || (score >= best_score && iformat != NULL)) {
+            best_score = score;
+            this->formatContext->iformat = iformat;
+        }
+
         if (score >= AVPROBE_SCORE_MAX / 4) {
             return;
         }
     }
 
         std::string bailText =
-            std::string("couldn't reliably guess input format, using last detected: ")
+            std::string("couldn't reliably guess input format, using best detected: ")
             + std::string(this->formatContext->iformat ? this->formatContext->iformat->name : "nothing");
 
     ::debug->Warning(TAG, bailText.c_str());

--- a/src/plugins/ffmpegdecoder/FfmpegDecoder.h
+++ b/src/plugins/ffmpegdecoder/FfmpegDecoder.h
@@ -84,6 +84,7 @@ class FfmpegDecoder: public musik::core::sdk::IDecoder {
         bool InitializeResampler();
         bool ReadSendAndReceivePacket(AVPacket* packet);
         void FlushAndFinalizeDecoder();
+        void GuessInputFormat(musik::core::sdk::IDataStream *stream);
 
         musik::core::sdk::IDataStream* stream;
         AVIOContext* ioContext;


### PR DESCRIPTION
# Summary

This fixes issue #720 (broken wma playback).
The issue seemed to be with the update on how `channel_layouts` were treated in ffmpeg 7.

# Details

When debugging I saw that for `wma` files the `codecContext` and the `decodedFrame`'s channel layout have the order set to `AV_CHANNEL_ORDER_UNSPEC` and `u.mask` set to `0`.
When the resampler was initialized using `swr_alloc_set_opts2` and the `codecContext`'s channel layout would then return an instance where `order` was set to `AV_CHANNEL_ORDER_NATIVE` and `u.mask` set to `3`, which then triggered an error with `swr_convert_frame`.

I fixed this by calling `resolveChannelLayout` in case the order is set to `AV_CHANNEL_ORDER_UNSPEC` in `codecContext`.

I'm not super sure if the fix is how ffmpeg wants things to be done, but when testing with a couple of file formats, none of them seemed to break. In fact `wma` was the only one that needed it's channel layout resolved. (I tested with mp3, ogg, opus, flac, wma, m4a, aac).

# Testing

System I used for testing: Llinux (ubuntu 25.10) with ffmpeg 7.1.1.

I looked through my music library and tried playing all different formats I found and didn't find any issues. I also ran `core_c_demo`, but not sure if that did anything meaningful.